### PR TITLE
Fix hardcoded fmparse.sh path in Explode XML script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,9 @@ xml_exports/
 agent/xml_parsed/
 agent/context/
 agent/CONTEXT.json
+agent/sandbox/
 .private/
+.venv/
 
 # Generated Claris documentation (copyright Claris International Inc.)
 # Run agent/docs/filemaker/fetch_docs.py to generate locally.

--- a/filemaker/README.md
+++ b/filemaker/README.md
@@ -116,7 +116,7 @@ Run the **Get agentic-fm path** script once (from the Scripts menu or Script Wor
 
 Run the **Explode XML** script to perform the first Save as XML export and populate `agent/xml_parsed/`. Re-run it any time the solution schema or scripts change.
 
-> **Current limitation:** The `fmparse.sh` path inside the **Explode XML** script is hardcoded to `~/Desktop/agentic-fm/fmparse.sh`. The repo must currently be located in your Desktop folder for this script to work. If your repo is elsewhere, open the script and update the `Set Variable [$fmparse]` step to reflect the correct path. This limitation will be resolved in a future update.
+> The script derives the `fmparse.sh` path from the `$$AGENTIC.FM` global variable set by **Get agentic-fm path**, so the repo can be located anywhere on disk.
 
 ### 5. Push Context before each AI session
 

--- a/filemaker/agentic-fm.xml
+++ b/filemaker/agentic-fm.xml
@@ -164,7 +164,7 @@
       <Step enable="True" id="89" name="# (comment)"/>
       <Step enable="True" id="141" name="Set Variable">
         <Value>
-          <Calculation><![CDATA["~/Desktop/agentic-fm/fmparse.sh"]]></Calculation>
+          <Calculation><![CDATA[ConvertFromFileMakerPath ( JSONGetElement ( $$AGENTIC.FM ; "path" ) ; 1 ) & "fmparse.sh"]]></Calculation>
         </Value>
         <Repetition>
           <Calculation><![CDATA[1]]></Calculation>


### PR DESCRIPTION
## Summary

The Explode XML companion script has `$fmparse` hardcoded to `~/Desktop/agentic-fm/fmparse.sh`, which requires the repo to live on the Desktop. This PR replaces it with a dynamic lookup from the `$$AGENTIC.FM` global variable that is already set by the **Get agentic-fm path** script.

**Before:**
```
"~/Desktop/agentic-fm/fmparse.sh"
```

**After:**
```
ConvertFromFileMakerPath ( JSONGetElement ( $$AGENTIC.FM ; "path" ) ; 1 ) & "fmparse.sh"
```

This resolves the limitation noted in `filemaker/README.md` — the repo can now be cloned anywhere on disk.

## Changes

- `filemaker/agentic-fm.xml` — Replace hardcoded path with `ConvertFromFileMakerPath` + `$$AGENTIC.FM` lookup
- `filemaker/README.md` — Update the "Current limitation" note to reflect the fix
- `.gitignore` — Add `agent/sandbox/` and `.venv/` (both are local working directories that should not be committed)

## Test plan

- [x] Cloned repo to a non-Desktop location (`~/Documents/GITs/...`)
- [x] Ran **Get agentic-fm path** and selected the repo folder
- [x] Ran **Explode XML** — completed successfully with `fmparse.sh` resolved via `$$AGENTIC.FM`
- [x] Verified `agent/xml_parsed/` was populated (623 files)
- [x] Verified `agent/context/` index files were generated