### PR TITLE
Add note about context to system prompt

### DIFF
--- a/webviewer/src/ai/prompt/system-prompt.ts
+++ b/webviewer/src/ai/prompt/system-prompt.ts
@@ -34,7 +34,9 @@ Format rules:
 - Field references use Table::Field notation: Invoices::Total
 - Variables use $ prefix (local) or $$ prefix (global): $invoiceId, $$USER
 - Let variables use ~ prefix in calculations: ~lineTotal
-- CRITICAL: All indentation inside calculations (Let, Case, List, etc.) MUST use hard tab characters, never spaces. This applies to any expression content inside square brackets.`);
+- CRITICAL: All indentation inside calculations (Let, Case, List, etc.) MUST use hard tab characters, never spaces. This applies to any expression content inside square brackets.
+
+The context has been injected, do not look for CONTEXT.json.`);
 
   // Coding conventions
   if (opts.codingConventions) {


### PR DESCRIPTION
The webviewer almost always tellms it doesn't have permission to read the CONTEXT.json file. I then need to tell it the context has been injected.
This quick change adds a note in the system prompt about using the injected context