### PR TITLE
Import logfile watch

### DIFF
--- a/agent/docs/COMPANION_SERVER.md
+++ b/agent/docs/COMPANION_SERVER.md
@@ -72,7 +72,8 @@ Startup log output now looks more like this:
 
 ```txt
 2026-03-29T19:10:00 INFO companion_server v1.0 listening on 127.0.0.1:8765
-2026-03-29T19:10:00 INFO Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push
+2026-03-29T19:10:00 INFO Watch UI: http://127.0.0.1:8765/watch/ui
+2026-03-29T19:10:00 INFO Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push
 2026-03-29T19:10:00 INFO Press Ctrl-C to stop.
 ```
 
@@ -170,7 +171,6 @@ launchctl unload ~/Library/LaunchAgents/com.agentic-fm.companion-server.plist
 | `GET`  | `/watch/results`          | Curated watch results payload                              |
 | `GET`  | `/watch/stream`           | SSE stream of live watch updates                           |
 | `GET`  | `/watch/ui`               | Built-in HTML UI for watch control and grouped import view |
-| `POST` | `/watch/start`            | Start watching an arbitrary local file                     |
 | `POST` | `/watch/import-log/start` | Start watching `Import.log` with automatic path resolution |
 | `POST` | `/watch/pick-path`        | Open a native file or folder picker on the host machine    |
 | `POST` | `/watch/stop`             | Stop current watch                                         |
@@ -531,14 +531,10 @@ The page provides:
 
 - **Auto Import.log Watch**
   - choose server or local mode
-  - choose analyzer
+  - set poll interval
   - provide database path or documents directory
   - browse for local files or folders using a native picker
   - auto-fill the host machine's default Documents directory
-
-- **Custom File Watch**
-  - watch any file path
-  - browse for the file using a native picker
 
 - **Live status**
   - current path
@@ -558,98 +554,9 @@ The page uses:
 
 - **`GET /watch/results`** for refresh
 - **`GET /watch/stream`** for live updates
-- **`POST /watch/start`** and **`POST /watch/import-log/start`** to begin watching
+- **`POST /watch/import-log/start`** to begin watching
 - **`POST /watch/pick-path`** to open host-native file/folder chooser dialogs
 - **`POST /watch/stop`** to stop watching
-
----
-
-### POST /watch/start
-
-Starts watching an arbitrary local file.
-
-The server uses a polling loop with standard library file reads. It tracks appended content and analyzes complete new lines.
-
-**Request body:**
-
-| Field           | Type             | Required | Description                                                                                |
-| --------------- | ---------------- | -------- | ------------------------------------------------------------------------------------------ |
-| `path`          | string           | Yes      | File path to monitor. `~` expansion is supported.                                          |
-| `poll_interval` | number           | No       | Poll interval in seconds. Default `0.5`. Must be `> 0`.                                    |
-| `start_at_end`  | boolean          | No       | If `true`, attach at end of existing file so only new content is analyzed. Default `true`. |
-| `analyzer`      | string or object | No       | Analyzer configuration. Default `import_log`.                                              |
-
-**Built-in analyzers:**
-
-- **`import_log`**
-  - tracks FileMaker import lifecycle lines
-  - reports all non-zero import log entries as issues
-
-- **`import_log_unknown_attributes`**
-  - narrower version for invalid attribute values only
-
-- **`regex`**
-  - custom rules defined by caller
-
-**Regex analyzer request example:**
-
-```json
-{
-  "path": "/tmp/app.log",
-  "poll_interval": 0.5,
-  "start_at_end": true,
-  "analyzer": {
-    "type": "regex",
-    "rules": [
-      {
-        "name": "error_line",
-        "pattern": "ERROR",
-        "severity": "error"
-      },
-      {
-        "name": "unknown_param",
-        "pattern": "unknown parameter",
-        "flags": "i",
-        "severity": "error"
-      }
-    ]
-  }
-}
-```
-
-**Import.log request example:**
-
-```json
-{
-  "path": "/Users/yourname/Documents/Import.log",
-  "poll_interval": 0.5,
-  "start_at_end": true,
-  "analyzer": "import_log"
-}
-```
-
-**Response:**
-
-```json
-{
-  "success": true,
-  "watch": {
-    "running": true,
-    "path": "/Users/yourname/Documents/Import.log",
-    "poll_interval": 0.5,
-    "start_at_end": true,
-    "analyzer": {
-      "type": "import_log"
-    }
-  }
-}
-```
-
-Notes:
-
-- starting a new watch stops any previous watch first
-- file truncation and recreation are handled
-- partial lines are buffered until newline arrives
 
 ---
 

--- a/agent/docs/COMPANION_SERVER.md
+++ b/agent/docs/COMPANION_SERVER.md
@@ -1,16 +1,56 @@
 # Companion Server
 
-The companion server is a lightweight HTTP server that exposes `fmparse.sh` as a local API endpoint. FileMaker calls it via the native **Insert from URL** script step, which functions as a curl-compatible HTTP client.
+The Companion Server is a lightweight local HTTP server for `agentic-fm`. It acts as the bridge between FileMaker Pro and host-side capabilities that FileMaker cannot perform by itself.
 
-**Why this exists:** FileMaker has no built-in mechanism to execute arbitrary shell commands. The companion server fills this gap — no third-party plugin is required. As long as the server is running on the developer's machine, FileMaker can trigger XML parsing and context generation through a simple HTTP POST.
+It currently provides 4 broad categories of functionality:
 
-**Windows gap:** The companion server approach is macOS-only at this time. `fmparse.sh` and `fm-xml-export-exploder` are Unix binaries.
+- **Shell command bridge**
+  - Runs `fmparse.sh` so FileMaker can trigger XML parsing.
+
+- **Local file write helpers**
+  - Writes `CONTEXT.json`, debug payloads, clipboard data, and webviewer output payloads.
+
+- **FileMaker automation bridge**
+  - Triggers FileMaker scripts via AppleScript and coordinates pending paste jobs.
+
+- **Live file monitoring and analysis**
+  - Watches a local file continuously.
+  - Detects changes in near real time.
+  - Analyzes appended content.
+  - Exposes results by JSON, SSE stream, terminal log output, and a built-in UI.
+
+This is especially useful for monitoring FileMaker's `Import.log` after importing script steps from the clipboard. If AI-generated script steps contain unknown attributes or invalid values, the server can now detect that automatically and surface it immediately.
+
+## Why this exists
+
+FileMaker has no built-in, first-party mechanism for:
+
+- **running arbitrary local shell commands**
+- **watching local files continuously**
+- **streaming live analysis results over HTTP**
+- **writing directly to the macOS clipboard**
+- **triggering host-side automation outside normal FM scripting**
+
+The Companion Server fills that gap using only Python standard library components.
+
+## Platform scope
+
+- **Primary target**
+  - macOS local development
+
+- **Why macOS matters**
+  - `osascript` is used for FileMaker automation
+  - clipboard integration is macOS-oriented
+  - `fmparse.sh` and `fm-xml-export-exploder` are Unix tooling
+
+- **Windows gap**
+  - not currently supported as a full equivalent environment
 
 ---
 
 ## Starting the server
 
-The server is a single Python file with no external dependencies beyond the standard library. No virtual environment is required — run it directly with `python3`:
+The server is a single Python file with no external Python dependencies.
 
 ```bash
 # Default port 8765
@@ -20,23 +60,33 @@ python3 agent/scripts/companion_server.py
 python3 agent/scripts/companion_server.py --port 9000
 ```
 
-Startup log output:
+By default it binds to `127.0.0.1`.
 
+Environment variable:
+
+- **`COMPANION_BIND_HOST`**
+  - overrides the bind host
+  - default: `127.0.0.1`
+
+Startup log output now looks more like this:
+
+```txt
+2026-03-29T19:10:00 INFO companion_server v1.0 listening on 127.0.0.1:8765
+2026-03-29T19:10:00 INFO Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push
+2026-03-29T19:10:00 INFO Press Ctrl-C to stop.
 ```
-2026-03-09T14:22:01 INFO companion_server v1.0 listening on 127.0.0.1:8765
-2026-03-09T14:22:01 INFO Endpoints: GET /health  POST /explode
-2026-03-09T14:22:01 INFO Press Ctrl-C to stop.
-```
+
+On startup the server also performs a background version check against the upstream `version.txt`. If a newer version is available, it logs a warning.
 
 ### Background process (Mac)
 
-To run the server in the background without blocking the terminal:
+To run the server in the background:
 
 ```bash
 python3 agent/scripts/companion_server.py &
 ```
 
-stdout logging will mix with your shell session. Redirect to a log file if that is disruptive:
+To redirect output:
 
 ```bash
 python3 agent/scripts/companion_server.py > /tmp/companion_server.log 2>&1 &
@@ -44,7 +94,7 @@ python3 agent/scripts/companion_server.py > /tmp/companion_server.log 2>&1 &
 
 ### Auto-start with launchd (Mac)
 
-To have the server start automatically at login, create a launchd plist. Replace the paths with your actual username and repo location:
+To start automatically at login, create a launchd plist.
 
 **`~/Library/LaunchAgents/com.agentic-fm.companion-server.plist`**
 
@@ -81,20 +131,20 @@ To have the server start automatically at login, create a launchd plist. Replace
 </plist>
 ```
 
-Load it immediately without logging out:
+Load it:
 
 ```bash
 launchctl load ~/Library/LaunchAgents/com.agentic-fm.companion-server.plist
 ```
 
-Verify it is running:
+Verify it:
 
 ```bash
 launchctl list | grep agentic-fm
 curl http://localhost:8765/health
 ```
 
-To unload (stop and disable auto-start):
+Unload it:
 
 ```bash
 launchctl unload ~/Library/LaunchAgents/com.agentic-fm.companion-server.plist
@@ -102,11 +152,60 @@ launchctl unload ~/Library/LaunchAgents/com.agentic-fm.companion-server.plist
 
 ---
 
+## Endpoint overview
+
+### Health and basic status
+
+| Method | Path       | Purpose                            |
+| ------ | ---------- | ---------------------------------- |
+| `GET`  | `/health`  | Liveness and version check         |
+| `GET`  | `/pending` | Return and clear pending paste job |
+| `POST` | `/pending` | Set pending paste job              |
+
+### File watch and live analysis
+
+| Method | Path                      | Purpose                                                    |
+| ------ | ------------------------- | ---------------------------------------------------------- |
+| `GET`  | `/watch/status`           | Full internal watch state snapshot                         |
+| `GET`  | `/watch/results`          | Curated watch results payload                              |
+| `GET`  | `/watch/stream`           | SSE stream of live watch updates                           |
+| `GET`  | `/watch/ui`               | Built-in HTML UI for watch control and results             |
+| `POST` | `/watch/start`            | Start watching an arbitrary local file                     |
+| `POST` | `/watch/import-log/start` | Start watching `Import.log` with automatic path resolution |
+| `POST` | `/watch/stop`             | Stop current watch                                         |
+
+### FileMaker workflow bridge
+
+| Method | Path         | Purpose                                  |
+| ------ | ------------ | ---------------------------------------- |
+| `POST` | `/explode`   | Run `fmparse.sh`                         |
+| `POST` | `/context`   | Write `agent/CONTEXT.json`               |
+| `POST` | `/clipboard` | Write XML to macOS clipboard             |
+| `POST` | `/trigger`   | Trigger FileMaker script via AppleScript |
+| `POST` | `/debug`     | Write runtime debug payload              |
+
+### Webviewer helper endpoints
+
+| Method | Path                | Purpose                                       |
+| ------ | ------------------- | --------------------------------------------- |
+| `GET`  | `/webviewer/status` | Check whether webviewer dev server is running |
+| `POST` | `/webviewer/start`  | Start the webviewer dev server                |
+| `POST` | `/webviewer/stop`   | Stop the webviewer dev server                 |
+| `POST` | `/webviewer/push`   | Write `.agent-output.json` for the webviewer  |
+
+---
+
 ## Endpoints
 
 ### GET /health
 
-A lightweight liveness check. FileMaker or the developer can poll this to confirm the server is up before triggering an explode operation.
+A lightweight liveness check.
+
+Use this when:
+
+- **FileMaker** wants to confirm the server is reachable before a workflow step
+- **a script** wants to sanity-check server availability
+- **a developer** wants to confirm the server is running
 
 **Request:**
 
@@ -123,6 +222,394 @@ No request body. No required headers.
   "status": "ok",
   "version": "1.0"
 }
+```
+
+---
+
+### GET /watch/status
+
+Returns the full current watch state snapshot.
+
+This is the most complete raw status endpoint. It exposes internal tracking fields such as:
+
+- **watch lifecycle**
+  - `running`
+  - `started_at`
+  - `path`
+  - `poll_interval`
+  - `start_at_end`
+
+- **file tracking**
+  - `file_exists`
+  - `offset`
+  - `last_checked_at`
+  - `last_change_at`
+
+- **analysis state**
+  - `analyzer`
+  - `summary`
+  - `recent_events`
+  - `last_error`
+  - `revision`
+
+**Response example:**
+
+```json
+{
+  "running": true,
+  "path": "/Users/yourname/Documents/Import.log",
+  "poll_interval": 0.5,
+  "start_at_end": true,
+  "started_at": "2026-03-29T17:11:54.102000+00:00",
+  "last_checked_at": "2026-03-29T17:12:10.402000+00:00",
+  "last_change_at": "2026-03-29T17:12:08.921000+00:00",
+  "last_event_at": "2026-03-29T17:12:08.922000+00:00",
+  "offset": 4821,
+  "file_exists": true,
+  "revision": 7,
+  "analyzer": {
+    "type": "import_log_unknown_attributes"
+  },
+  "summary": {
+    "events_total": 3,
+    "errors_total": 3,
+    "matches_by_rule": {
+      "unknown_attribute": 3
+    },
+    "current_import": {},
+    "last_completed_import": {
+      "source": "FileName.fmp12",
+      "started_at": "2026-03-27 16:21:28.370 +0100",
+      "error_count": 3,
+      "imported_steps": 260,
+      "completed_at": "2026-03-27 16:21:28.420 +0100"
+    },
+    "last_error": {
+      "rule": "unknown_attribute",
+      "message": "Attribute value “ExitAfterLast” unknown."
+    }
+  },
+  "recent_events": [],
+  "last_error": ""
+}
+```
+
+---
+
+### GET /watch/results
+
+Returns a curated watch payload intended for polling clients and the built-in UI.
+
+Compared with `/watch/status`, this omits some lower-level internal fields and focuses on the values most useful to a consumer.
+
+**Response example:**
+
+```json
+{
+  "running": true,
+  "path": "/Users/yourname/Documents/Import.log",
+  "poll_interval": 0.5,
+  "start_at_end": true,
+  "started_at": "2026-03-29T17:11:54.102000+00:00",
+  "file_exists": true,
+  "revision": 7,
+  "analyzer": {
+    "type": "import_log_unknown_attributes"
+  },
+  "summary": {
+    "events_total": 3,
+    "errors_total": 3,
+    "matches_by_rule": {
+      "unknown_attribute": 3
+    },
+    "current_import": {},
+    "last_completed_import": {
+      "source": "FileName.fmp12",
+      "started_at": "2026-03-27 16:21:28.370 +0100",
+      "error_count": 3,
+      "imported_steps": 260,
+      "completed_at": "2026-03-27 16:21:28.420 +0100"
+    },
+    "last_error": {
+      "rule": "unknown_attribute",
+      "message": "Attribute value “ExitAfterLast” unknown."
+    }
+  },
+  "recent_events": [
+    {
+      "event_type": "import_log_issue",
+      "rule": "unknown_attribute",
+      "severity": "error",
+      "script_name": "ScriptName",
+      "script_line": "160",
+      "step_name": "Go to Record/Request/Page",
+      "attribute_name": "Step",
+      "unknown_value": "ExitAfterLast",
+      "message": "Attribute value “ExitAfterLast” unknown."
+    }
+  ],
+  "last_change_at": "2026-03-29T17:12:08.921000+00:00",
+  "last_event_at": "2026-03-29T17:12:08.922000+00:00",
+  "last_error": ""
+}
+```
+
+---
+
+### GET /watch/stream
+
+Streams live watch updates as **Server-Sent Events**.
+
+This is the push-style alternative to polling `/watch/results`.
+
+Behavior:
+
+- **Event type `results`**
+  - sent whenever watch state revision changes
+  - payload is the same shape as `/watch/results`
+
+- **Event type `ping`**
+  - sent periodically when no state change occurred
+  - keeps the connection alive
+
+**Request:**
+
+```txt
+GET http://localhost:8765/watch/stream
+Accept: text/event-stream
+```
+
+**Example stream:**
+
+```txt
+id: 12
+event: results
+data: {"running":true,"path":"/Users/yourname/Documents/Import.log","revision":12,...}
+
+event: ping
+data: {"timestamp":"2026-03-29T17:12:20.000000+00:00"}
+```
+
+---
+
+### GET /watch/ui
+
+Serves a built-in HTML UI for the watch subsystem.
+
+Open in a browser:
+
+```txt
+http://127.0.0.1:8765/watch/ui
+```
+
+The page provides:
+
+- **Auto Import.log Watch**
+  - choose server or local mode
+  - choose analyzer
+  - provide database path or documents directory
+
+- **Custom File Watch**
+  - watch any file path
+
+- **Live status**
+  - current path
+  - analyzer
+  - revision
+  - last change
+  - last event
+
+- **Summary and event list**
+  - current import
+  - last completed import
+  - recent events
+
+The page uses:
+
+- **`GET /watch/results`** for refresh
+- **`GET /watch/stream`** for live updates
+- **`POST /watch/start`** and **`POST /watch/import-log/start`** to begin watching
+- **`POST /watch/stop`** to stop watching
+
+---
+
+### POST /watch/start
+
+Starts watching an arbitrary local file.
+
+The server uses a polling loop with standard library file reads. It tracks appended content and analyzes complete new lines.
+
+**Request body:**
+
+| Field           | Type             | Required | Description                                                                                |
+| --------------- | ---------------- | -------- | ------------------------------------------------------------------------------------------ |
+| `path`          | string           | Yes      | File path to monitor. `~` expansion is supported.                                          |
+| `poll_interval` | number           | No       | Poll interval in seconds. Default `0.5`. Must be `> 0`.                                    |
+| `start_at_end`  | boolean          | No       | If `true`, attach at end of existing file so only new content is analyzed. Default `true`. |
+| `analyzer`      | string or object | No       | Analyzer configuration. Default `import_log`.                                              |
+
+**Built-in analyzers:**
+
+- **`import_log`**
+  - tracks FileMaker import lifecycle lines
+  - reports all non-zero import log entries as issues
+
+- **`import_log_unknown_attributes`**
+  - narrower version for invalid attribute values only
+
+- **`regex`**
+  - custom rules defined by caller
+
+**Regex analyzer request example:**
+
+```json
+{
+  "path": "/tmp/app.log",
+  "poll_interval": 0.5,
+  "start_at_end": true,
+  "analyzer": {
+    "type": "regex",
+    "rules": [
+      {
+        "name": "error_line",
+        "pattern": "ERROR",
+        "severity": "error"
+      },
+      {
+        "name": "unknown_param",
+        "pattern": "unknown parameter",
+        "flags": "i",
+        "severity": "error"
+      }
+    ]
+  }
+}
+```
+
+**Import.log request example:**
+
+```json
+{
+  "path": "/Users/yourname/Documents/Import.log",
+  "poll_interval": 0.5,
+  "start_at_end": true,
+  "analyzer": "import_log_unknown_attributes"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "watch": {
+    "running": true,
+    "path": "/Users/yourname/Documents/Import.log",
+    "poll_interval": 0.5,
+    "start_at_end": true,
+    "analyzer": {
+      "type": "import_log_unknown_attributes"
+    }
+  }
+}
+```
+
+Notes:
+
+- starting a new watch stops any previous watch first
+- file truncation and recreation are handled
+- partial lines are buffered until newline arrives
+
+---
+
+### POST /watch/import-log/start
+
+Starts a watch specifically for FileMaker's `Import.log`, with automatic path resolution.
+
+This is the recommended endpoint for clipboard-import monitoring.
+
+**Request body:**
+
+| Field             | Type             | Required | Description                                                                      |
+| ----------------- | ---------------- | -------- | -------------------------------------------------------------------------------- |
+| `location`        | string           | No       | `server` or `local`. If omitted, inferred from `database_path` / `database_dir`. |
+| `mode`            | string           | No       | Alias for `location`.                                                            |
+| `import_log_path` | string           | No       | Explicit full path override. If provided, wins over all inference.               |
+| `documents_dir`   | string           | No       | Directory used for `server` mode. Default `~/Documents`.                         |
+| `database_path`   | string           | No       | Path to a local `.fmp12` file or local database directory.                       |
+| `database_dir`    | string           | No       | Explicit local directory containing `Import.log`.                                |
+| `poll_interval`   | number           | No       | Poll interval in seconds. Default `0.5`.                                         |
+| `start_at_end`    | boolean          | No       | Default `true`.                                                                  |
+| `analyzer`        | string or object | No       | Default `import_log_unknown_attributes`.                                         |
+
+**Resolution rules:**
+
+- **explicit path override**
+  - if `import_log_path` is provided, it is used directly
+
+- **server mode**
+  - resolves to `{documents_dir}/Import.log`
+  - default documents directory is `~/Documents`
+
+- **local mode**
+  - resolves to `<database dir>/Import.log`
+  - accepts either a file path or a directory path
+
+**Server file example:**
+
+```json
+{
+  "location": "server",
+  "analyzer": "import_log_unknown_attributes"
+}
+```
+
+**Local file example:**
+
+```json
+{
+  "location": "local",
+  "database_path": "/Users/yourname/Projects/MySolution/MySolution.fmp12",
+  "analyzer": "import_log_unknown_attributes"
+}
+```
+
+**Response example:**
+
+```json
+{
+  "success": true,
+  "location": "local",
+  "resolved_path": "/Users/yourname/Projects/MySolution/Import.log",
+  "watch": {
+    "running": true,
+    "path": "/Users/yourname/Projects/MySolution/Import.log",
+    "analyzer": {
+      "type": "import_log_unknown_attributes"
+    }
+  }
+}
+```
+
+---
+
+### POST /watch/stop
+
+Stops the current watch if one is running.
+
+**Request body:**
+
+- **none required**
+  - an empty body or `{}` is fine
+
+**Response examples:**
+
+```json
+{ "success": true, "status": "stopped" }
+```
+
+```json
+{ "success": true, "status": "not_running" }
 ```
 
 ---
@@ -224,27 +711,68 @@ Writes a CONTEXT.json file to the agentic-fm project on the host. Called by the 
 
 ### GET /pending
 
-Returns and clears the pending paste job set by the most recent `/trigger` call. Called by the `Agentic-fm Paste` FM script to retrieve the target script name and `auto_save` flag without relying on AppleScript parameter passing (which is unreliable in FM Pro 22).
+Returns and clears the pending paste job set by `/trigger` or `/pending`.
 
-**Response:**
+This is used because FileMaker Pro 22 does not reliably receive AppleScript `do script ... given parameter:` values in all flows.
+
+The pending job may contain:
+
+- **`target`**
+  - target script or target name
+
+- **`auto_save`**
+  - whether the receiving FM script should save after paste
+
+- **`select_all`**
+  - whether the receiving FM script should select all before pasting
+
+**Response example:**
+
 ```json
-{ "target": "ScriptName", "auto_save": false }
+{
+  "target": "ScriptName",
+  "auto_save": false,
+  "select_all": true
+}
 ```
 
-Returns `{ "target": "", "auto_save": false }` if no pending job is set. The job is cleared on read (consumed once).
+If no pending job exists, the server currently returns an empty object:
+
+```json
+{}
+```
+
+The job is consumed on read.
 
 ---
 
 ### POST /pending
 
-Sets the pending paste job directly (without triggering a script). Used for testing or custom trigger flows.
+Sets the pending paste job directly.
+
+Useful for:
+
+- **testing**
+- **custom trigger flows**
+- **manual job injection**
 
 **Request body:**
+
 ```json
-{ "target": "ScriptName", "auto_save": true }
+{
+  "target": "ScriptName",
+  "auto_save": true,
+  "select_all": true
+}
 ```
 
-**Response:** `{ "success": true }`
+`select_all` defaults to `true` if omitted.
+
+**Response:**
+
+```json
+{ "success": true }
+```
 
 ---
 
@@ -270,26 +798,54 @@ Triggers FM Pro on the host to run a named FileMaker script via AppleScript (`os
 {
   "fm_app_name": "FileMaker Pro — 22.0.4.406",
   "script": "Agentic-fm Paste",
-  "parameter": "TargetScriptName"
+  "parameter": "TargetScriptName",
+  "target_file": "MySolution",
+  "auto_save": false,
+  "select_all": true
 }
 ```
-`parameter` is optional. `fm_app_name` must match the exact AppleScript application name (versioned, with em dash).
+
+Additional supported fields:
+
+- **`parameter`**
+  - optional
+  - stored in the server-side pending job instead of being passed directly to `do script`
+
+- **`target_file`**
+  - optional
+  - if provided, AppleScript targets the first FileMaker document whose name contains this string
+
+- **`raw_applescript`**
+  - optional
+  - bypasses the normal FileMaker script trigger template and runs arbitrary AppleScript
+
+`fm_app_name` must match the exact AppleScript application name if a versioned FileMaker app name is required.
 
 The AppleScript template used:
 ```applescript
 tell application "FileMaker Pro — 22.0.4.406"
     activate
     tell document 1
-        do script "Agentic-fm Paste" given parameter:"TargetScriptName"
+        do script "Agentic-fm Paste"
     end tell
 end tell
 ```
 
 **Response:** `{ "success": bool, "stdout": str, "stderr": str }`
 
-**Parameter passing note:** FM Pro 22 does not reliably receive script parameters via `given parameter:` in `do script`. When `parameter` is provided, the server stores it in an internal pending job before firing AppleScript. The triggered FM script calls `GET /pending` via Insert from URL to retrieve the target and `auto_save` flag. The pending job is cleared on first read.
+If `target_file` is provided, the server uses a document-targeted AppleScript clause instead of `tell document 1`.
+
+**Parameter passing note:** FM Pro 22 does not reliably receive script parameters via `given parameter:` in `do script`. When `parameter` is provided, the server stores it in an internal pending job before firing AppleScript. The triggered FM script then calls `GET /pending` to retrieve:
+
+- `target`
+- `auto_save`
+- `select_all`
+
+The pending job is cleared on first read.
 
 **`auto_save` field:** Pass `"auto_save": true` to instruct `Agentic-fm Paste` to save all scripts after paste (via `Perform AppleScript: tell application "System Events" to keystroke "s" using {command down}`). Defaults to `false`.
+
+**`select_all` field:** Pass `"select_all": false` if the receiving FM script should skip select-all before paste. Defaults to `true`.
 
 **Requirements:**
 - macOS only (`osascript` must be available on the host)
@@ -310,6 +866,180 @@ Accepts a JSON payload of runtime debug state and writes it to `agent/debug/outp
 
 ---
 
+### GET /webviewer/status
+
+Returns whether the companion-managed webviewer dev server is running.
+
+**Response:**
+
+```json
+{ "running": true }
+```
+
+---
+
+### POST /webviewer/start
+
+Starts the `webviewer` development server by running `npm run dev` in `{repo_path}/webviewer`.
+
+**Request body:**
+
+```json
+{ "repo_path": "/absolute/path/to/agentic-fm" }
+```
+
+**Response examples:**
+
+```json
+{ "success": true, "status": "started", "pid": 12345 }
+```
+
+```json
+{ "success": true, "status": "already_running" }
+```
+
+---
+
+### POST /webviewer/stop
+
+Stops the companion-managed webviewer dev server process group.
+
+**Response examples:**
+
+```json
+{ "success": true, "status": "stopped" }
+```
+
+```json
+{ "success": true, "status": "not_running" }
+```
+
+---
+
+### POST /webviewer/push
+
+Writes an agent output payload to:
+
+```txt
+{repo_path}/agent/config/.agent-output.json
+```
+
+This is used by the webviewer to pick up agent output through polling.
+
+**Request body:**
+
+| Field       | Type   | Required | Description                                                     |
+| ----------- | ------ | -------- | --------------------------------------------------------------- |
+| `type`      | string | Yes      | One of `preview`, `diff`, `result`, `diagram`, `layout-preview` |
+| `content`   | string | No       | Main content payload                                            |
+| `before`    | string | No       | Optional secondary text                                         |
+| `styles`    | string | No       | Optional styles field, mainly for `layout-preview`              |
+| `repo_path` | string | Yes      | Repository root                                                 |
+
+**Example request:**
+
+```json
+{
+  "type": "result",
+  "content": "Import completed",
+  "repo_path": "/absolute/path/to/agentic-fm"
+}
+```
+
+**Response:**
+
+```json
+{
+  "success": true,
+  "path": "/absolute/path/to/agentic-fm/agent/config/.agent-output.json"
+}
+```
+
+---
+
+## File watch and `Import.log` analysis
+
+The new watch subsystem is designed for this workflow:
+
+1. **A local file changes**
+2. **The server detects the change automatically**
+3. **New content is analyzed immediately**
+4. **Results are exposed through terminal logs, JSON, SSE, and the UI**
+
+### How the watch loop works
+
+- **poll-based watcher**
+  - implemented with Python standard library only
+  - no external dependency like `watchdog`
+
+- **single active watch**
+  - only one file watch runs at a time
+  - starting a new one replaces the old one
+
+- **incremental reading**
+  - remembers the current file offset
+  - reads only newly appended content
+
+- **partial line buffering**
+  - incomplete last line is buffered until newline arrives
+
+- **truncation handling**
+  - if file size shrinks, offset resets automatically
+
+### Built-in `Import.log` analysis
+
+The import analyzers understand FileMaker `Import.log` lines in the form:
+
+```txt
+2026-03-27 16:21:28.380 +0100	ScriptName::31::New Window::LayoutDestination	11	Attribute value “OriginalLayout” unknown.
+```
+
+The parser extracts:
+
+- **timestamp**
+- **source**
+- **script name**
+- **script line**
+- **step name**
+- **attribute name**
+- **code**
+- **message**
+- **unknown value** when the message matches `Attribute value ... unknown.`
+
+### Import lifecycle tracking
+
+The server also tracks import lifecycle lines such as:
+
+- **`Import of script steps from clipboard started`**
+- **`script steps imported : N`**
+- **`Import completed`**
+
+This allows it to build:
+
+- **`summary.current_import`**
+- **`summary.last_completed_import`**
+- **error count during an import**
+- **imported step count**
+
+### Terminal log output
+
+When an issue is detected, the server logs a warning immediately. For import log issues it includes structured detail such as:
+
+- **script**
+- **line**
+- **step**
+- **attribute**
+- **unknown value**
+- **message**
+
+Example:
+
+```txt
+2026-03-29T19:12:08 WARNING File watch match [unknown_attribute]: script=ScriptName line=160 step=Go to Record/Request/Page attribute=Step value=ExitAfterLast message=Attribute value “ExitAfterLast” unknown.
+```
+
+---
+
 ## Security
 
 **This project is designed exclusively for local development.** It assumes you are working on your own machine, behind a firewall, on a private network. It is not hardened for production use, multi-user environments, or any network-accessible deployment. Do not use it on a public network or expose any part of it to the internet.
@@ -324,13 +1054,25 @@ Do not change `BIND_HOST` to `0.0.0.0` or expose the server through a reverse pr
 
 ## FileMaker integration
 
-FileMaker calls the server from an "Explode XML" companion script using the **Insert from URL** step. The step is configured with:
+### Explode XML flow
 
-- **URL:** `http://localhost:8765/explode`
-- **Method:** POST
-- **cURL options:** `--header "Content-Type: application/json" --data @$json_payload`
+FileMaker can call the Companion Server from an **Insert from URL** step.
 
-The FileMaker script builds the JSON payload by assembling field values and preference globals into a Let calculation, then fires the request. A typical payload as assembled in FileMaker:
+Typical explode configuration:
+
+- **URL**
+  - `http://localhost:8765/explode`
+
+- **Method**
+  - `POST`
+
+- **Headers**
+  - `Content-Type: application/json`
+
+- **cURL body**
+  - assembled JSON payload
+
+Example payload:
 
 ```json
 {
@@ -340,9 +1082,49 @@ The FileMaker script builds the JSON payload by assembling field values and pref
 }
 ```
 
-After Insert from URL completes, the script parses the response JSON, checks `success`, and branches accordingly — displaying an error dialog if `success` is `false` or proceeding to refresh context if the parse succeeded.
+After Insert from URL completes, the FileMaker script can parse the response JSON and branch on `success`.
 
-If Insert from URL itself fails (e.g. the server is not running), FileMaker displays its own connection-refused dialog before the script can evaluate the response.
+### Clipboard-import error monitoring flow
+
+This is the new workflow enabled by the watch subsystem.
+
+Recommended sequence:
+
+1. **Start Import.log watch**
+   - call `POST /watch/import-log/start`
+   - use `import_log_unknown_attributes`
+
+2. **Import script steps from clipboard in FileMaker**
+
+3. **Read results**
+   - poll `GET /watch/results`
+   - or keep `GET /watch/stream` open
+   - or inspect `/watch/ui`
+   - or watch the terminal where the server is running
+
+This is useful when AI-generated script steps contain unknown parameters or invalid attribute values.
+
+### Pending job flow for paste automation
+
+The server-side pending job exists because direct AppleScript parameter passing is unreliable in FM Pro 22.
+
+Typical pattern:
+
+1. **Call `POST /trigger`** with `parameter`, `auto_save`, and optional `select_all`
+2. **Server stores pending job**
+3. **AppleScript triggers FM script**
+4. **FM script calls `GET /pending`**
+5. **FM script consumes target/options and continues**
+
+### Watch UI usage
+
+If you want a browser-based monitor during development:
+
+```txt
+http://127.0.0.1:8765/watch/ui
+```
+
+This is useful when you want a persistent live view without manually polling the JSON endpoints.
 
 ---
 
@@ -401,6 +1183,84 @@ chmod +x ~/bin/fm-xml-export-exploder
 
 If the binary is in a non-standard location and not on `PATH`, supply its full path in the `exploder_bin_path` field of the request payload.
 
+### `Import.log` watch starts but no events appear
+
+Check these first:
+
+- **wrong file path**
+  - use `GET /watch/results` or `/watch/ui` to inspect `path` and `file_exists`
+
+- **watch attached at end of file**
+  - default behavior is `start_at_end: true`
+  - only lines appended after watch start are analyzed
+
+- **wrong analyzer**
+  - `import_log_unknown_attributes` only reports unknown attribute values
+  - use `import_log` if you want all non-zero import log issues
+
+- **no newline yet**
+  - partial final lines are buffered until newline arrives
+
+### `Import.log` path resolution is wrong
+
+Use `POST /watch/import-log/start` response fields:
+
+- `location`
+- `resolved_path`
+
+If needed, override everything with:
+
+```json
+{
+  "import_log_path": "/absolute/path/to/Import.log"
+}
+```
+
+### SSE stream does not update
+
+Verify:
+
+- **the watch is actually running**
+  - `GET /watch/results`
+
+- **you are connected to `/watch/stream`**
+  - browser dev tools network tab helps here
+
+- **state revision is changing**
+  - `revision` increments when watch state changes
+
+If no new events occur, periodic `ping` events keep the connection alive.
+
+### Built-in watch UI loads but shows no data
+
+The UI depends on:
+
+- `GET /watch/results`
+- `GET /watch/stream`
+
+If those endpoints fail, inspect the browser console and the server terminal log.
+
+### `POST /trigger` fails
+
+Common causes:
+
+- **FileMaker not running**
+- **wrong `fm_app_name`**
+- **target file not open** when using `target_file`
+- **missing `fmextscriptaccess` privilege**
+- **Accessibility permissions missing** when workflow depends on System Events keystrokes
+
+Typical failures return in `stderr`.
+
+### `/webviewer/start` fails
+
+Check:
+
+- `repo_path` is correct
+- `{repo_path}/webviewer` exists
+- Node/npm are installed
+- the webviewer project can run `npm run dev`
+
 ### Diagnosing failures from the server log
 
 When the server is running in the foreground (or writing to a log file), each request produces timestamped output:
@@ -411,4 +1271,6 @@ When the server is running in the foreground (or writing to a log file), each re
 2026-03-09T14:25:12 INFO fmparse.sh exited with code 0
 ```
 
-The `stdout` and `stderr` fields in the response body contain the full output of `fmparse.sh`, which is the first place to look when the exit code is non-zero.
+For watch issues, the server log is also the first place to inspect because watch matches are emitted there immediately.
+
+The `stdout` and `stderr` fields in the response body remain the first place to inspect when `/explode` returns a non-zero exit code.

--- a/agent/docs/COMPANION_SERVER.md
+++ b/agent/docs/COMPANION_SERVER.md
@@ -19,7 +19,7 @@ It currently provides 4 broad categories of functionality:
   - Analyzes appended content.
   - Exposes results by JSON, SSE stream, terminal log output, and a built-in UI.
 
-This is especially useful for monitoring FileMaker's `Import.log` after importing script steps from the clipboard. If AI-generated script steps contain unknown attributes or invalid values, the server can now detect that automatically and surface it immediately.
+This is especially useful for monitoring FileMaker's `Import.log` after importing script steps from the clipboard. The watch subsystem now surfaces full import lifecycle events, grouped import sessions, and all non-zero import errors — not only unknown attribute values.
 
 ## Why this exists
 
@@ -72,7 +72,7 @@ Startup log output now looks more like this:
 
 ```txt
 2026-03-29T19:10:00 INFO companion_server v1.0 listening on 127.0.0.1:8765
-2026-03-29T19:10:00 INFO Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push
+2026-03-29T19:10:00 INFO Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push
 2026-03-29T19:10:00 INFO Press Ctrl-C to stop.
 ```
 
@@ -169,9 +169,10 @@ launchctl unload ~/Library/LaunchAgents/com.agentic-fm.companion-server.plist
 | `GET`  | `/watch/status`           | Full internal watch state snapshot                         |
 | `GET`  | `/watch/results`          | Curated watch results payload                              |
 | `GET`  | `/watch/stream`           | SSE stream of live watch updates                           |
-| `GET`  | `/watch/ui`               | Built-in HTML UI for watch control and results             |
+| `GET`  | `/watch/ui`               | Built-in HTML UI for watch control and grouped import view |
 | `POST` | `/watch/start`            | Start watching an arbitrary local file                     |
 | `POST` | `/watch/import-log/start` | Start watching `Import.log` with automatic path resolution |
+| `POST` | `/watch/pick-path`        | Open a native file or folder picker on the host machine    |
 | `POST` | `/watch/stop`             | Stop current watch                                         |
 
 ### FileMaker workflow bridge
@@ -226,6 +227,39 @@ No request body. No required headers.
 
 ---
 
+### POST /watch/pick-path
+
+Opens a native file or folder chooser on the host machine running the Companion Server.
+
+This is intended for the built-in Watch UI so local paths can be selected without manually typing them.
+
+**Request body:**
+
+| Field            | Type   | Required | Description                                        |
+| ---------------- | ------ | -------- | -------------------------------------------------- |
+| `selection_type` | string | No       | `file` or `directory`. Default `file`.             |
+| `initial_path`   | string | No       | Initial file or folder hint for the picker dialog. |
+| `title`          | string | No       | Custom dialog title.                               |
+
+**Response example:**
+
+```json
+{
+  "success": true,
+  "selected_path": "/Users/yourname/Documents/Import.log",
+  "cancelled": false
+}
+```
+
+Notes:
+
+- tries `tkinter` first if available
+- on macOS, falls back to native `osascript` dialogs
+- on Windows, falls back to PowerShell dialogs
+- if the dialog is cancelled, `selected_path` is empty and `cancelled` is `true`
+
+---
+
 ### GET /watch/status
 
 Returns the full current watch state snapshot.
@@ -268,29 +302,83 @@ This is the most complete raw status endpoint. It exposes internal tracking fiel
   "file_exists": true,
   "revision": 7,
   "analyzer": {
-    "type": "import_log_unknown_attributes"
+    "type": "import_log"
   },
   "summary": {
-    "events_total": 3,
-    "errors_total": 3,
+    "events_total": 5,
+    "errors_total": 2,
     "matches_by_rule": {
-      "unknown_attribute": 3
+      "import_started": 1,
+      "missing_function": 1,
+      "missing_field": 1,
+      "import_steps_imported": 1,
+      "import_completed": 1
+    },
+    "errors_by_code": {
+      "102": 1,
+      "1208": 1
     },
     "current_import": {},
     "last_completed_import": {
       "source": "FileName.fmp12",
+      "database_name": "FileName.fmp12",
+      "script_name": "ScriptName",
       "started_at": "2026-03-27 16:21:28.370 +0100",
-      "error_count": 3,
+      "error_count": 2,
       "imported_steps": 260,
-      "completed_at": "2026-03-27 16:21:28.420 +0100"
+      "completed_at": "2026-03-27 16:21:28.420 +0100",
+      "status": "with_errors",
+      "errors": [
+        {
+          "line_number": "31",
+          "step_name": "Set Variable",
+          "label": "Missing function",
+          "code": "1208",
+          "message": "Function referred to in the calculation “cf_Param_Get ( \"Prozess\" )” is missing."
+        },
+        {
+          "line_number": "42",
+          "step_name": "Set Field",
+          "label": "Missing field",
+          "code": "102",
+          "message": "Field “FertigungFreigabeStatus” missing."
+        }
+      ]
     },
+    "recent_imports": [
+      {
+        "script_name": "ScriptName",
+        "imported_steps": 260,
+        "status": "with_errors"
+      }
+    ],
+    "imports_total": 12,
+    "imports_with_errors": 2,
+    "imports_without_errors": 10,
     "last_error": {
-      "rule": "unknown_attribute",
-      "message": "Attribute value “ExitAfterLast” unknown."
+      "rule": "missing_field",
+      "message": "Field “FertigungFreigabeStatus” missing."
     }
   },
-  "recent_events": [],
-  "last_error": ""
+  "recent_events": [
+    {
+      "event_type": "import_log_lifecycle",
+      "rule": "import_completed",
+      "severity": "warn",
+      "import_status": "with_errors",
+      "imported_steps": 260,
+      "error_count": 2,
+      "message": "Import completed with 2 errors."
+    }
+  ],
+  "last_error": "",
+  "platform": {
+    "system": "Darwin",
+    "python_platform": "darwin"
+  },
+  "defaults": {
+    "documents_dir": "/Users/yourname/Documents"
+  }
 }
 ```
 
@@ -314,43 +402,78 @@ Compared with `/watch/status`, this omits some lower-level internal fields and f
   "file_exists": true,
   "revision": 7,
   "analyzer": {
-    "type": "import_log_unknown_attributes"
+    "type": "import_log"
   },
   "summary": {
-    "events_total": 3,
-    "errors_total": 3,
+    "events_total": 5,
+    "errors_total": 2,
     "matches_by_rule": {
-      "unknown_attribute": 3
+      "import_started": 1,
+      "missing_function": 1,
+      "missing_field": 1,
+      "import_steps_imported": 1,
+      "import_completed": 1
+    },
+    "errors_by_code": {
+      "102": 1,
+      "1208": 1
     },
     "current_import": {},
     "last_completed_import": {
       "source": "FileName.fmp12",
+      "database_name": "FileName.fmp12",
+      "script_name": "ScriptName",
       "started_at": "2026-03-27 16:21:28.370 +0100",
-      "error_count": 3,
+      "error_count": 2,
       "imported_steps": 260,
-      "completed_at": "2026-03-27 16:21:28.420 +0100"
+      "completed_at": "2026-03-27 16:21:28.420 +0100",
+      "status": "with_errors",
+      "errors": [
+        {
+          "line_number": "31",
+          "step_name": "Set Variable",
+          "label": "Missing function",
+          "code": "1208",
+          "message": "Function referred to in the calculation “cf_Param_Get ( \"Prozess\" )” is missing."
+        }
+      ]
+    },
+    "recent_imports": [
+      {
+        "script_name": "ScriptName",
+        "imported_steps": 260,
+        "status": "with_errors"
+      }
     },
     "last_error": {
-      "rule": "unknown_attribute",
-      "message": "Attribute value “ExitAfterLast” unknown."
+      "rule": "missing_field",
+      "message": "Field “FertigungFreigabeStatus” missing."
     }
   },
   "recent_events": [
     {
       "event_type": "import_log_issue",
-      "rule": "unknown_attribute",
+      "rule": "missing_function",
       "severity": "error",
       "script_name": "ScriptName",
-      "script_line": "160",
-      "step_name": "Go to Record/Request/Page",
-      "attribute_name": "Step",
-      "unknown_value": "ExitAfterLast",
-      "message": "Attribute value “ExitAfterLast” unknown."
+      "script_line": "31",
+      "line_number": "31",
+      "step_name": "Set Variable",
+      "label": "Missing function",
+      "code": "1208",
+      "message": "Function referred to in the calculation “cf_Param_Get ( \"Prozess\" )” is missing."
     }
   ],
   "last_change_at": "2026-03-29T17:12:08.921000+00:00",
   "last_event_at": "2026-03-29T17:12:08.922000+00:00",
-  "last_error": ""
+  "last_error": "",
+  "platform": {
+    "system": "Darwin",
+    "python_platform": "darwin"
+  },
+  "defaults": {
+    "documents_dir": "/Users/yourname/Documents"
+  }
 }
 ```
 
@@ -396,6 +519,8 @@ data: {"timestamp":"2026-03-29T17:12:20.000000+00:00"}
 
 Serves a built-in HTML UI for the watch subsystem.
 
+The UI is now loaded from `agent/scripts/companion_watch_ui.html`, not embedded inline in the Python source.
+
 Open in a browser:
 
 ```txt
@@ -408,9 +533,12 @@ The page provides:
   - choose server or local mode
   - choose analyzer
   - provide database path or documents directory
+  - browse for local files or folders using a native picker
+  - auto-fill the host machine's default Documents directory
 
 - **Custom File Watch**
   - watch any file path
+  - browse for the file using a native picker
 
 - **Live status**
   - current path
@@ -419,16 +547,19 @@ The page provides:
   - last change
   - last event
 
-- **Summary and event list**
-  - current import
-  - last completed import
-  - recent events
+- **Grouped import session view**
+  - current import session
+  - recent completed import sessions
+  - per-import script name and imported step count
+  - compact per-error rows with line number first
+  - successful imports that show no errors
 
 The page uses:
 
 - **`GET /watch/results`** for refresh
 - **`GET /watch/stream`** for live updates
 - **`POST /watch/start`** and **`POST /watch/import-log/start`** to begin watching
+- **`POST /watch/pick-path`** to open host-native file/folder chooser dialogs
 - **`POST /watch/stop`** to stop watching
 
 ---
@@ -493,7 +624,7 @@ The server uses a polling loop with standard library file reads. It tracks appen
   "path": "/Users/yourname/Documents/Import.log",
   "poll_interval": 0.5,
   "start_at_end": true,
-  "analyzer": "import_log_unknown_attributes"
+  "analyzer": "import_log"
 }
 ```
 
@@ -508,7 +639,7 @@ The server uses a polling loop with standard library file reads. It tracks appen
     "poll_interval": 0.5,
     "start_at_end": true,
     "analyzer": {
-      "type": "import_log_unknown_attributes"
+      "type": "import_log"
     }
   }
 }
@@ -535,12 +666,12 @@ This is the recommended endpoint for clipboard-import monitoring.
 | `location`        | string           | No       | `server` or `local`. If omitted, inferred from `database_path` / `database_dir`. |
 | `mode`            | string           | No       | Alias for `location`.                                                            |
 | `import_log_path` | string           | No       | Explicit full path override. If provided, wins over all inference.               |
-| `documents_dir`   | string           | No       | Directory used for `server` mode. Default `~/Documents`.                         |
+| `documents_dir`   | string           | No       | Directory used for `server` mode. Default is the host OS Documents folder.       |
 | `database_path`   | string           | No       | Path to a local `.fmp12` file or local database directory.                       |
 | `database_dir`    | string           | No       | Explicit local directory containing `Import.log`.                                |
 | `poll_interval`   | number           | No       | Poll interval in seconds. Default `0.5`.                                         |
 | `start_at_end`    | boolean          | No       | Default `true`.                                                                  |
-| `analyzer`        | string or object | No       | Default `import_log_unknown_attributes`.                                         |
+| `analyzer`        | string or object | No       | Default `import_log`.                                                            |
 
 **Resolution rules:**
 
@@ -549,7 +680,9 @@ This is the recommended endpoint for clipboard-import monitoring.
 
 - **server mode**
   - resolves to `{documents_dir}/Import.log`
-  - default documents directory is `~/Documents`
+  - default documents directory is resolved per host OS
+  - macOS and Linux typically resolve to `~/Documents`
+  - Windows resolves to the user's real Documents folder when available
 
 - **local mode**
   - resolves to `<database dir>/Import.log`
@@ -560,7 +693,7 @@ This is the recommended endpoint for clipboard-import monitoring.
 ```json
 {
   "location": "server",
-  "analyzer": "import_log_unknown_attributes"
+  "analyzer": "import_log"
 }
 ```
 
@@ -570,7 +703,7 @@ This is the recommended endpoint for clipboard-import monitoring.
 {
   "location": "local",
   "database_path": "/Users/yourname/Projects/MySolution/MySolution.fmp12",
-  "analyzer": "import_log_unknown_attributes"
+  "analyzer": "import_log"
 }
 ```
 
@@ -585,7 +718,7 @@ This is the recommended endpoint for clipboard-import monitoring.
     "running": true,
     "path": "/Users/yourname/Projects/MySolution/Import.log",
     "analyzer": {
-      "type": "import_log_unknown_attributes"
+      "type": "import_log"
     }
   }
 }
@@ -1006,6 +1139,18 @@ The parser extracts:
 - **message**
 - **unknown value** when the message matches `Attribute value ... unknown.`
 
+It also classifies common FileMaker import error categories such as:
+
+- **missing field**
+- **missing table reference**
+- **missing function**
+- **missing script**
+- **missing layout**
+- **missing field reference**
+- **missing attribute**
+- **unknown attribute value**
+- **unknown error**
+
 ### Import lifecycle tracking
 
 The server also tracks import lifecycle lines such as:
@@ -1018,8 +1163,12 @@ This allows it to build:
 
 - **`summary.current_import`**
 - **`summary.last_completed_import`**
+- **`summary.recent_imports`**
 - **error count during an import**
 - **imported step count**
+- **per-import compact error rows**
+- **counts of successful vs failing imports**
+- **error counts by FileMaker code**
 
 ### Terminal log output
 
@@ -1035,7 +1184,7 @@ When an issue is detected, the server logs a warning immediately. For import log
 Example:
 
 ```txt
-2026-03-29T19:12:08 WARNING File watch match [unknown_attribute]: script=ScriptName line=160 step=Go to Record/Request/Page attribute=Step value=ExitAfterLast message=Attribute value “ExitAfterLast” unknown.
+2026-03-29T19:12:08 WARNING File watch match [missing_function]: script=ScriptName line=31 step=Set Variable attribute= value= message=Function referred to in the calculation “cf_Param_Get ( "Prozess" )” is missing.
 ```
 
 ---
@@ -1092,7 +1241,7 @@ Recommended sequence:
 
 1. **Start Import.log watch**
    - call `POST /watch/import-log/start`
-   - use `import_log_unknown_attributes`
+   - use `import_log`
 
 2. **Import script steps from clipboard in FileMaker**
 
@@ -1102,7 +1251,7 @@ Recommended sequence:
    - or inspect `/watch/ui`
    - or watch the terminal where the server is running
 
-This is useful when AI-generated script steps contain unknown parameters or invalid attribute values.
+This is useful when AI-generated script steps contain unknown parameters, missing references, layout/script/function issues, or any other non-zero import log errors.
 
 ### Pending job flow for paste automation
 
@@ -1125,6 +1274,17 @@ http://127.0.0.1:8765/watch/ui
 ```
 
 This is useful when you want a persistent live view without manually polling the JSON endpoints.
+
+The current Watch UI is optimized around grouped import sessions instead of a flat recent-event list.
+
+Each import card shows:
+
+- **script name**
+- **import status**
+- **imported line count**
+- **error count**
+- **compact error rows with line number first**
+- **a no-error message for successful imports**
 
 ---
 
@@ -1238,7 +1398,37 @@ The UI depends on:
 - `GET /watch/results`
 - `GET /watch/stream`
 
+The path picker buttons also depend on:
+
+- `POST /watch/pick-path`
+
 If those endpoints fail, inspect the browser console and the server terminal log.
+
+### Path picker buttons fail
+
+The Watch UI path picker tries multiple host-native strategies.
+
+Behavior:
+
+- **first choice**
+  - `tkinter`, if available in the Python build
+
+- **macOS fallback**
+  - `osascript`
+
+- **Windows fallback**
+  - PowerShell dialogs
+
+If clicking a picker button still fails:
+
+- **restart the Companion Server**
+  - old running code may still be active
+
+- **check the server terminal log**
+  - picker failures are logged there
+
+- **enter the path manually**
+  - all picker fields still accept direct text input
 
 ### `POST /trigger` fails
 

--- a/agent/docs/COMPANION_SERVER.md
+++ b/agent/docs/COMPANION_SERVER.md
@@ -533,7 +533,7 @@ The page provides:
   - choose server or local mode
   - set poll interval
   - provide database path or documents directory
-  - browse for local files or folders using a native picker
+  - browse for the local database folder using a native picker
   - auto-fill the host machine's default Documents directory
 
 - **Live status**
@@ -574,7 +574,7 @@ This is the recommended endpoint for clipboard-import monitoring.
 | `mode`            | string           | No       | Alias for `location`.                                                            |
 | `import_log_path` | string           | No       | Explicit full path override. If provided, wins over all inference.               |
 | `documents_dir`   | string           | No       | Directory used for `server` mode. Default is the host OS Documents folder.       |
-| `database_path`   | string           | No       | Path to a local `.fmp12` file or local database directory.                       |
+| `database_path`   | string           | No       | Path to a local database directory. The built-in UI fills this with a folder.    |
 | `database_dir`    | string           | No       | Explicit local directory containing `Import.log`.                                |
 | `poll_interval`   | number           | No       | Poll interval in seconds. Default `0.5`.                                         |
 | `start_at_end`    | boolean          | No       | Default `true`.                                                                  |
@@ -609,7 +609,7 @@ This is the recommended endpoint for clipboard-import monitoring.
 ```json
 {
   "location": "local",
-  "database_path": "/Users/yourname/Projects/MySolution/MySolution.fmp12",
+  "database_path": "/Users/yourname/Projects/MySolution",
   "analyzer": "import_log"
 }
 ```

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -20,12 +20,15 @@ import argparse
 import json
 import logging
 import os
+import re
 import signal
+import socket
 import subprocess
 import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -38,6 +41,9 @@ from socketserver import ThreadingMixIn
 DEFAULT_PORT = 8765
 BIND_HOST = os.environ.get("COMPANION_BIND_HOST", "127.0.0.1")
 REMOTE_VERSION_URL = "https://raw.githubusercontent.com/petrowsky/agentic-fm/main/version.txt"
+FILE_WATCH_POLL_INTERVAL_SECONDS = 0.5
+FILE_WATCH_MAX_EVENTS = 100
+IMPORT_LOG_UNKNOWN_VALUE_RE = re.compile(r'Attribute value [“"](.+?)[”"] unknown\.')
 
 # Read version from version.txt at the repo root
 def _read_local_version() -> str:
@@ -64,6 +70,35 @@ _webviewer_lock = threading.Lock()
 _pending_job: dict = {}
 _pending_lock = threading.Lock()
 
+_file_watch_thread: "threading.Thread | None" = None
+_file_watch_stop_event: "threading.Event | None" = None
+_file_watch_lock = threading.Lock()
+_file_watch_condition = threading.Condition(_file_watch_lock)
+_file_watch_state: dict = {
+    "running": False,
+    "path": "",
+    "poll_interval": FILE_WATCH_POLL_INTERVAL_SECONDS,
+    "start_at_end": True,
+    "started_at": None,
+    "last_checked_at": None,
+    "last_change_at": None,
+    "last_event_at": None,
+    "offset": None,
+    "file_exists": False,
+    "revision": 0,
+    "analyzer": {"type": "import_log"},
+    "summary": {
+        "events_total": 0,
+        "errors_total": 0,
+        "matches_by_rule": {},
+        "current_import": {},
+        "last_completed_import": {},
+        "last_error": {},
+    },
+    "recent_events": [],
+    "last_error": "",
+}
+
 # ---------------------------------------------------------------------------
 # Logging setup
 # ---------------------------------------------------------------------------
@@ -76,6 +111,764 @@ logging.basicConfig(
 )
 log = logging.getLogger("companion_server")
 SUBPROCESS_HEARTBEAT_SECONDS = 5
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _clone_jsonable(data):
+    return json.loads(json.dumps(data, ensure_ascii=False))
+
+
+def _snapshot_file_watch_state() -> dict:
+    with _file_watch_lock:
+        return _clone_jsonable(_file_watch_state)
+
+
+def _watch_results_payload_from_state(state: dict) -> dict:
+    return {
+        "running": state["running"],
+        "path": state["path"],
+        "poll_interval": state["poll_interval"],
+        "start_at_end": state["start_at_end"],
+        "started_at": state["started_at"],
+        "file_exists": state["file_exists"],
+        "revision": state.get("revision", 0),
+        "analyzer": state["analyzer"],
+        "summary": state["summary"],
+        "recent_events": state["recent_events"],
+        "last_change_at": state["last_change_at"],
+        "last_event_at": state["last_event_at"],
+        "last_error": state["last_error"],
+    }
+
+
+def _current_watch_results_payload() -> dict:
+    return _watch_results_payload_from_state(_snapshot_file_watch_state())
+
+
+def _bump_file_watch_revision_locked() -> int:
+    _file_watch_state["revision"] = int(_file_watch_state.get("revision", 0)) + 1
+    _file_watch_condition.notify_all()
+    return _file_watch_state["revision"]
+
+
+def _normalize_analyzer_config(raw_analyzer) -> dict:
+    if not raw_analyzer:
+        return {"type": "import_log"}
+
+    if isinstance(raw_analyzer, str):
+        analyzer = {"type": raw_analyzer}
+    elif isinstance(raw_analyzer, dict):
+        analyzer = dict(raw_analyzer)
+    else:
+        raise ValueError("analyzer must be a string or object")
+
+    analyzer_type = analyzer.get("type", "import_log")
+    if analyzer_type in ("import_log", "import_log_unknown_attributes"):
+        return {"type": analyzer_type}
+
+    if analyzer_type != "regex":
+        raise ValueError("analyzer.type must be import_log, import_log_unknown_attributes, or regex")
+
+    rules = analyzer.get("rules")
+    if not isinstance(rules, list) or not rules:
+        raise ValueError("regex analyzer requires a non-empty rules array")
+
+    normalized_rules = []
+    for index, rule in enumerate(rules, start=1):
+        if not isinstance(rule, dict):
+            raise ValueError(f"regex rule #{index} must be an object")
+        name = str(rule.get("name") or f"rule_{index}")
+        pattern = rule.get("pattern") or rule.get("regex")
+        if not pattern:
+            raise ValueError(f"regex rule {name!r} is missing pattern")
+        flags = str(rule.get("flags", ""))
+        severity = str(rule.get("severity", "info"))
+        re_flags = 0
+        if "i" in flags.lower():
+            re_flags |= re.IGNORECASE
+        try:
+            re.compile(pattern, re_flags)
+        except re.error as exc:
+            raise ValueError(f"regex rule {name!r} is invalid: {exc}") from exc
+        normalized_rules.append(
+            {
+                "name": name,
+                "pattern": pattern,
+                "flags": flags,
+                "severity": severity,
+            }
+        )
+
+    return {"type": "regex", "rules": normalized_rules}
+
+
+def _build_analyzer_runtime(analyzer_config: dict) -> dict:
+    if analyzer_config["type"] != "regex":
+        return analyzer_config
+
+    runtime_rules = []
+    for rule in analyzer_config["rules"]:
+        re_flags = 0
+        if "i" in rule.get("flags", "").lower():
+            re_flags |= re.IGNORECASE
+        runtime_rules.append(
+            {
+                "name": rule["name"],
+                "severity": rule["severity"],
+                "compiled": re.compile(rule["pattern"], re_flags),
+            }
+        )
+    return {"type": "regex", "rules": runtime_rules}
+
+
+def _record_watch_event_locked(event: dict):
+    summary = _file_watch_state["summary"]
+    summary["events_total"] += 1
+    if event.get("severity") == "error":
+        summary["errors_total"] += 1
+        summary["last_error"] = event
+        current_import = summary.get("current_import") or {}
+        if current_import:
+            current_import["error_count"] = int(current_import.get("error_count", 0)) + 1
+            summary["current_import"] = current_import
+
+    rule = event.get("rule", "unknown")
+    summary["matches_by_rule"][rule] = summary["matches_by_rule"].get(rule, 0) + 1
+
+    _file_watch_state["last_event_at"] = event.get("detected_at")
+    _file_watch_state["recent_events"].append(event)
+    if len(_file_watch_state["recent_events"]) > FILE_WATCH_MAX_EVENTS:
+        _file_watch_state["recent_events"] = _file_watch_state["recent_events"][-FILE_WATCH_MAX_EVENTS:]
+    _bump_file_watch_revision_locked()
+
+
+def _parse_import_log_line(line: str) -> dict | None:
+    parts = line.split("\t", 3)
+    if len(parts) != 4:
+        return None
+
+    timestamp_str, source, code, message = parts
+    parsed = {
+        "timestamp": timestamp_str,
+        "source": source,
+        "code": code,
+        "message": message,
+        "raw_line": line,
+    }
+
+    source_parts = source.split("::")
+    if len(source_parts) >= 1:
+        parsed["script_name"] = source_parts[0]
+    if len(source_parts) >= 2:
+        parsed["script_line"] = source_parts[1]
+    if len(source_parts) >= 3:
+        parsed["step_name"] = source_parts[2]
+    if len(source_parts) >= 4:
+        parsed["attribute_name"] = source_parts[3]
+
+    unknown_match = IMPORT_LOG_UNKNOWN_VALUE_RE.search(message)
+    if unknown_match:
+        parsed["unknown_value"] = unknown_match.group(1)
+
+    imported_match = re.search(r"script steps imported\s*:\s*(\d+)", message)
+    if imported_match:
+        parsed["imported_steps"] = int(imported_match.group(1))
+
+    return parsed
+
+
+def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
+    parsed = _parse_import_log_line(line)
+    if not parsed:
+        return []
+
+    events = []
+    with _file_watch_lock:
+        summary = _file_watch_state["summary"]
+        message = parsed["message"]
+        code = parsed["code"]
+        source = parsed["source"]
+        state_changed = False
+
+        if message == "Import of script steps from clipboard started":
+            summary["current_import"] = {
+                "source": source,
+                "started_at": parsed["timestamp"],
+                "error_count": 0,
+            }
+            state_changed = True
+
+        if "imported_steps" in parsed:
+            current_import = summary.get("current_import") or {}
+            current_import["imported_steps"] = parsed["imported_steps"]
+            summary["current_import"] = current_import
+            state_changed = True
+
+        if message == "Import completed":
+            current_import = dict(summary.get("current_import") or {})
+            if current_import:
+                current_import["completed_at"] = parsed["timestamp"]
+                summary["last_completed_import"] = current_import
+            summary["current_import"] = {}
+            state_changed = True
+
+        if state_changed:
+            _bump_file_watch_revision_locked()
+
+        if code == "0":
+            return []
+
+        if analyzer_type == "import_log_unknown_attributes" and "unknown_value" not in parsed:
+            return []
+
+        rule_name = "unknown_attribute" if "unknown_value" in parsed else "import_log_error"
+        event = {
+            "detected_at": _utc_now_iso(),
+            "event_type": "import_log_issue",
+            "rule": rule_name,
+            "severity": "error",
+            "timestamp": parsed["timestamp"],
+            "source": source,
+            "code": code,
+            "message": message,
+            "script_name": parsed.get("script_name", ""),
+            "script_line": parsed.get("script_line", ""),
+            "step_name": parsed.get("step_name", ""),
+            "attribute_name": parsed.get("attribute_name", ""),
+            "unknown_value": parsed.get("unknown_value", ""),
+            "raw_line": parsed["raw_line"],
+        }
+        _record_watch_event_locked(event)
+        events.append(event)
+
+    return events
+
+
+def _process_regex_line(line: str, analyzer_runtime: dict) -> list[dict]:
+    events = []
+    for rule in analyzer_runtime["rules"]:
+        match = rule["compiled"].search(line)
+        if not match:
+            continue
+        event = {
+            "detected_at": _utc_now_iso(),
+            "event_type": "regex_match",
+            "rule": rule["name"],
+            "severity": rule["severity"],
+            "message": line,
+            "groups": match.groupdict() or {str(index): value for index, value in enumerate(match.groups(), start=1)},
+            "raw_line": line,
+        }
+        with _file_watch_lock:
+            _record_watch_event_locked(event)
+        events.append(event)
+    return events
+
+
+def _process_watch_lines(lines: list[str], analyzer_runtime: dict) -> list[dict]:
+    events = []
+    for line in lines:
+        stripped = line.rstrip("\r\n")
+        if not stripped:
+            continue
+        if analyzer_runtime["type"] in ("import_log", "import_log_unknown_attributes"):
+            events.extend(_process_import_log_line(stripped, analyzer_runtime["type"]))
+        elif analyzer_runtime["type"] == "regex":
+            events.extend(_process_regex_line(stripped, analyzer_runtime))
+    return events
+
+
+def _watch_file_loop(path: str, poll_interval: float, start_at_end: bool, analyzer_runtime: dict, stop_event: threading.Event):
+    carryover = ""
+
+    while True:
+        if stop_event.wait(poll_interval):
+            return
+
+        file_exists = os.path.exists(path)
+        now = _utc_now_iso()
+        with _file_watch_lock:
+            file_exists_changed = _file_watch_state["file_exists"] != file_exists
+            _file_watch_state["last_checked_at"] = now
+            _file_watch_state["file_exists"] = file_exists
+            if file_exists_changed:
+                _bump_file_watch_revision_locked()
+
+        if not file_exists:
+            continue
+
+        try:
+            with _file_watch_lock:
+                current_offset = _file_watch_state["offset"]
+            file_size = os.path.getsize(path)
+
+            if current_offset is not None and file_size < current_offset:
+                carryover = ""
+                with _file_watch_lock:
+                    _file_watch_state["offset"] = 0
+                current_offset = 0
+                log.info("File watch reset offset after truncation: %s", path)
+
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
+                if current_offset is None:
+                    if start_at_end:
+                        f.seek(0, os.SEEK_END)
+                        new_offset = f.tell()
+                        with _file_watch_lock:
+                            _file_watch_state["offset"] = new_offset
+                        log.info("File watch attached to %s at end of file", path)
+                        continue
+                    current_offset = 0
+
+                f.seek(current_offset)
+                chunk = f.read()
+                new_offset = f.tell()
+
+            if new_offset == current_offset:
+                continue
+
+            text = carryover + chunk
+            split_lines = text.splitlines(keepends=True)
+            complete_lines = []
+            carryover = ""
+            for index, split_line in enumerate(split_lines):
+                is_last = index == len(split_lines) - 1
+                if is_last and not split_line.endswith(("\n", "\r")):
+                    carryover = split_line
+                else:
+                    complete_lines.append(split_line)
+
+            with _file_watch_lock:
+                _file_watch_state["offset"] = new_offset
+                _file_watch_state["last_change_at"] = now
+                _bump_file_watch_revision_locked()
+
+            events = _process_watch_lines(complete_lines, analyzer_runtime)
+            for event in events:
+                if event["event_type"] == "import_log_issue":
+                    log.warning(
+                        "File watch match [%s]: script=%s line=%s step=%s attribute=%s value=%s message=%s",
+                        event["rule"],
+                        event.get("script_name", ""),
+                        event.get("script_line", ""),
+                        event.get("step_name", ""),
+                        event.get("attribute_name", ""),
+                        event.get("unknown_value", ""),
+                        event.get("message", ""),
+                    )
+                else:
+                    log.warning(
+                        "File watch match [%s]: %s",
+                        event["rule"],
+                        event.get("message", ""),
+                    )
+        except Exception as exc:
+            with _file_watch_lock:
+                _file_watch_state["last_error"] = str(exc)
+                _bump_file_watch_revision_locked()
+            log.warning("File watch error for %s: %s", path, exc)
+
+
+def _stop_file_watch() -> bool:
+    global _file_watch_thread, _file_watch_stop_event
+    thread = None
+    with _file_watch_lock:
+        if _file_watch_stop_event is not None:
+            _file_watch_stop_event.set()
+        thread = _file_watch_thread
+
+    if thread is not None:
+        thread.join(timeout=2)
+
+    with _file_watch_lock:
+        was_running = _file_watch_state["running"]
+        _file_watch_thread = None
+        _file_watch_stop_event = None
+        _file_watch_state["running"] = False
+        _bump_file_watch_revision_locked()
+
+    return was_running
+
+
+def _start_file_watch(path: str, poll_interval: float, start_at_end: bool, analyzer_config: dict) -> dict:
+    global _file_watch_thread, _file_watch_stop_event
+
+    _stop_file_watch()
+
+    expanded_path = os.path.expanduser(path)
+    analyzer_runtime = _build_analyzer_runtime(analyzer_config)
+    initial_offset = None
+    if os.path.exists(expanded_path):
+        with open(expanded_path, "r", encoding="utf-8", errors="replace") as f:
+            if start_at_end:
+                f.seek(0, os.SEEK_END)
+                initial_offset = f.tell()
+            else:
+                initial_offset = 0
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_watch_file_loop,
+        args=(expanded_path, poll_interval, start_at_end, analyzer_runtime, stop_event),
+        daemon=True,
+    )
+
+    with _file_watch_lock:
+        _file_watch_stop_event = stop_event
+        _file_watch_thread = thread
+        _file_watch_state["running"] = True
+        _file_watch_state["path"] = expanded_path
+        _file_watch_state["poll_interval"] = poll_interval
+        _file_watch_state["start_at_end"] = start_at_end
+        _file_watch_state["started_at"] = _utc_now_iso()
+        _file_watch_state["last_checked_at"] = None
+        _file_watch_state["last_change_at"] = None
+        _file_watch_state["last_event_at"] = None
+        _file_watch_state["offset"] = initial_offset
+        _file_watch_state["file_exists"] = os.path.exists(expanded_path)
+        _file_watch_state["revision"] = 0
+        _file_watch_state["analyzer"] = _clone_jsonable(analyzer_config)
+        _file_watch_state["summary"] = {
+            "events_total": 0,
+            "errors_total": 0,
+            "matches_by_rule": {},
+            "current_import": {},
+            "last_completed_import": {},
+            "last_error": {},
+        }
+        _file_watch_state["recent_events"] = []
+        _file_watch_state["last_error"] = ""
+        _bump_file_watch_revision_locked()
+
+    thread.start()
+    return _snapshot_file_watch_state()
+
+
+def _resolve_import_log_path(payload: dict) -> dict:
+    explicit_path = payload.get("import_log_path", "")
+    if explicit_path:
+        return {
+            "location": "explicit",
+            "path": os.path.expanduser(explicit_path),
+        }
+
+    database_path = payload.get("database_path", "")
+    database_dir = payload.get("database_dir", "")
+    location = str(payload.get("location", "") or payload.get("mode", "")).strip().lower()
+    if not location:
+        location = "local" if database_path or database_dir else "server"
+
+    if location == "server":
+        documents_dir = os.path.expanduser(payload.get("documents_dir", "~/Documents"))
+        return {
+            "location": "server",
+            "path": os.path.join(documents_dir, "Import.log"),
+        }
+
+    if location == "local":
+        local_root = database_dir or database_path
+        if not local_root:
+            raise ValueError("database_path or database_dir is required when location is local")
+        expanded_local_root = os.path.expanduser(local_root)
+        if database_dir:
+            resolved_database_dir = expanded_local_root
+        elif expanded_local_root.endswith(os.sep) or os.path.isdir(expanded_local_root):
+            resolved_database_dir = expanded_local_root
+        elif expanded_local_root.lower().endswith(".fmp12"):
+            resolved_database_dir = os.path.dirname(expanded_local_root)
+        elif "." not in os.path.basename(expanded_local_root):
+            resolved_database_dir = expanded_local_root
+        else:
+            resolved_database_dir = os.path.dirname(expanded_local_root)
+        if not resolved_database_dir:
+            resolved_database_dir = os.getcwd()
+        return {
+            "location": "local",
+            "path": os.path.join(resolved_database_dir, "Import.log"),
+        }
+
+    raise ValueError("location must be server or local")
+
+
+def _build_watch_ui_html() -> str:
+    return """<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Companion Watch</title>
+  <style>
+    :root { color-scheme: dark; }
+    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b1020; color: #e5e7eb; }
+    .wrap { max-width: 1180px; margin: 0 auto; padding: 24px; }
+    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
+    .panel { background: #121933; border: 1px solid #26304f; border-radius: 14px; padding: 16px; box-shadow: 0 10px 30px rgba(0,0,0,.18); }
+    .panel.full { grid-column: 1 / -1; }
+    h1, h2 { margin: 0 0 12px; }
+    h1 { font-size: 24px; }
+    h2 { font-size: 16px; }
+    .muted { color: #93a1c6; }
+    .row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-bottom: 12px; }
+    .row.single { grid-template-columns: 1fr; }
+    label { display: block; font-size: 12px; color: #93a1c6; margin-bottom: 6px; }
+    input, select, button, textarea { width: 100%; box-sizing: border-box; border-radius: 10px; border: 1px solid #334269; background: #0f1530; color: #eef2ff; padding: 10px 12px; font: inherit; }
+    textarea { min-height: 110px; resize: vertical; }
+    button { cursor: pointer; background: linear-gradient(180deg, #4169e1, #3558c8); border: none; font-weight: 600; }
+    button.secondary { background: #1a2342; border: 1px solid #334269; }
+    button.danger { background: linear-gradient(180deg, #c9405e, #a52d48); }
+    .button-row { display: flex; gap: 10px; flex-wrap: wrap; }
+    .badge { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: 999px; background: #1a2342; color: #c7d2fe; font-size: 12px; margin-right: 8px; }
+    .badge.ok { background: #16351e; color: #9ae6b4; }
+    .badge.warn { background: #3a2712; color: #fbd38d; }
+    .badge.err { background: #3d1620; color: #feb2b2; }
+    .kv { display: grid; grid-template-columns: 180px 1fr; gap: 8px; font-size: 13px; }
+    .events { display: grid; gap: 10px; }
+    .event { border: 1px solid #2e395d; border-radius: 12px; padding: 12px; background: #0d1430; }
+    .event.error { border-color: #7f2940; }
+    .event .meta { color: #93a1c6; font-size: 12px; margin-bottom: 6px; }
+    .event .msg { white-space: pre-wrap; word-break: break-word; }
+    pre { margin: 0; white-space: pre-wrap; word-break: break-word; background: #0d1430; border: 1px solid #2e395d; border-radius: 12px; padding: 12px; }
+    @media (max-width: 900px) { .grid, .row { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <div class=\"wrap\">
+    <div style=\"display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px;flex-wrap:wrap;\">
+      <div>
+        <h1>Companion Watch</h1>
+        <div class=\"muted\">Live file watch, Import.log auto-resolution, SSE stream, and recent event view.</div>
+      </div>
+      <div>
+        <span id=\"runningBadge\" class=\"badge\">stopped</span>
+        <span id=\"streamBadge\" class=\"badge\">stream idle</span>
+      </div>
+    </div>
+    <div class=\"grid\">
+      <section class=\"panel\">
+        <h2>Auto Import.log Watch</h2>
+        <div class=\"row\">
+          <div>
+            <label for=\"importLocation\">Location</label>
+            <select id=\"importLocation\">
+              <option value=\"server\">Server file</option>
+              <option value=\"local\">Local database file</option>
+            </select>
+          </div>
+          <div>
+            <label for=\"importAnalyzer\">Analyzer</label>
+            <select id=\"importAnalyzer\">
+              <option value=\"import_log_unknown_attributes\">Unknown attributes only</option>
+              <option value=\"import_log\">All Import.log issues</option>
+            </select>
+          </div>
+        </div>
+        <div class=\"row single\">
+          <div>
+            <label for=\"databasePath\">Database path or folder for local file mode</label>
+            <input id=\"databasePath\" placeholder=\"/path/to/MyFile.fmp12\">
+          </div>
+        </div>
+        <div class=\"row\">
+          <div>
+            <label for=\"documentsDir\">Documents dir for server mode</label>
+            <input id=\"documentsDir\" value=\"~/Documents\">
+          </div>
+          <div>
+            <label for=\"importPollInterval\">Poll interval</label>
+            <input id=\"importPollInterval\" value=\"0.5\">
+          </div>
+        </div>
+        <div class=\"button-row\">
+          <button id=\"startImportButton\">Start Import.log watch</button>
+        </div>
+      </section>
+      <section class=\"panel\">
+        <h2>Custom File Watch</h2>
+        <div class=\"row single\">
+          <div>
+            <label for=\"customPath\">File path</label>
+            <input id=\"customPath\" placeholder=\"/path/to/file.log\">
+          </div>
+        </div>
+        <div class=\"row\">
+          <div>
+            <label for=\"customAnalyzer\">Analyzer</label>
+            <select id=\"customAnalyzer\">
+              <option value=\"import_log_unknown_attributes\">Import.log unknown attributes</option>
+              <option value=\"import_log\">Import.log issues</option>
+            </select>
+          </div>
+          <div>
+            <label for=\"customPollInterval\">Poll interval</label>
+            <input id=\"customPollInterval\" value=\"0.5\">
+          </div>
+        </div>
+        <div class=\"row single\">
+          <div>
+            <label for=\"startAtEnd\">Start at end of file</label>
+            <select id=\"startAtEnd\">
+              <option value=\"true\">true</option>
+              <option value=\"false\">false</option>
+            </select>
+          </div>
+        </div>
+        <div class=\"button-row\">
+          <button id=\"startCustomButton\">Start custom watch</button>
+          <button id=\"stopButton\" class=\"danger\">Stop watch</button>
+          <button id=\"refreshButton\" class=\"secondary\">Refresh</button>
+        </div>
+      </section>
+      <section class=\"panel full\">
+        <h2>Status</h2>
+        <div id=\"statusGrid\" class=\"kv\"></div>
+      </section>
+      <section class=\"panel\">
+        <h2>Summary</h2>
+        <pre id=\"summaryView\">{}</pre>
+      </section>
+      <section class=\"panel\">
+        <h2>Current / Last Import</h2>
+        <pre id=\"importView\">{}</pre>
+      </section>
+      <section class=\"panel full\">
+        <h2>Recent Events</h2>
+        <div id=\"events\" class=\"events\"></div>
+      </section>
+    </div>
+  </div>
+  <script>
+    const $ = (id) => document.getElementById(id);
+    let stream = null;
+
+    function escapeHtml(value) {
+      return String(value ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
+    }
+
+    async function request(path, method = 'GET', body = null) {
+      const response = await fetch(path, {
+        method,
+        headers: body ? { 'Content-Type': 'application/json' } : {},
+        body: body ? JSON.stringify(body) : null,
+      });
+      const text = await response.text();
+      const data = text ? JSON.parse(text) : {};
+      if (!response.ok) {
+        throw new Error(data.error || `HTTP ${response.status}`);
+      }
+      return data;
+    }
+
+    function render(state) {
+      const running = Boolean(state.running);
+      $('runningBadge').textContent = running ? 'running' : 'stopped';
+      $('runningBadge').className = `badge ${running ? 'ok' : 'warn'}`;
+      $('statusGrid').innerHTML = [
+        ['Path', state.path || ''],
+        ['File exists', String(Boolean(state.file_exists))],
+        ['Analyzer', state.analyzer?.type || ''],
+        ['Poll interval', String(state.poll_interval ?? '')],
+        ['Started at', state.started_at || ''],
+        ['Last change', state.last_change_at || ''],
+        ['Last event', state.last_event_at || ''],
+        ['Last error', state.last_error || ''],
+        ['Revision', String(state.revision ?? '')],
+      ].map(([key, value]) => `<div class=\"muted\">${escapeHtml(key)}</div><div>${escapeHtml(value)}</div>`).join('');
+
+      $('summaryView').textContent = JSON.stringify(state.summary || {}, null, 2);
+      $('importView').textContent = JSON.stringify({
+        current_import: state.summary?.current_import || {},
+        last_completed_import: state.summary?.last_completed_import || {},
+      }, null, 2);
+
+      const events = [...(state.recent_events || [])].reverse();
+      $('events').innerHTML = events.length ? events.map((event) => {
+        const bits = [
+          event.detected_at || '',
+          event.rule || '',
+          event.script_name || '',
+          event.script_line || '',
+          event.step_name || '',
+          event.attribute_name || '',
+          event.unknown_value || '',
+        ].filter(Boolean).join(' · ');
+        return `<div class=\"event ${escapeHtml(event.severity || '')}\"><div class=\"meta\">${escapeHtml(bits)}</div><div class=\"msg\">${escapeHtml(event.message || event.raw_line || '')}</div></div>`;
+      }).join('') : '<div class=\"muted\">No events yet.</div>';
+    }
+
+    async function refresh() {
+      try {
+        const state = await request('/watch/results');
+        render(state);
+      } catch (error) {
+        $('streamBadge').textContent = error.message;
+        $('streamBadge').className = 'badge err';
+      }
+    }
+
+    function connectStream() {
+      if (stream) {
+        stream.close();
+      }
+      stream = new EventSource('/watch/stream');
+      $('streamBadge').textContent = 'connecting';
+      $('streamBadge').className = 'badge warn';
+      stream.addEventListener('results', (event) => {
+        $('streamBadge').textContent = 'live';
+        $('streamBadge').className = 'badge ok';
+        render(JSON.parse(event.data));
+      });
+      stream.onerror = () => {
+        $('streamBadge').textContent = 'reconnecting';
+        $('streamBadge').className = 'badge warn';
+      };
+    }
+
+    async function startImportWatch() {
+      const payload = {
+        location: $('importLocation').value,
+        database_path: $('databasePath').value.trim(),
+        documents_dir: $('documentsDir').value.trim(),
+        poll_interval: Number($('importPollInterval').value || '0.5'),
+        analyzer: $('importAnalyzer').value,
+        start_at_end: true,
+      };
+      await request('/watch/import-log/start', 'POST', payload);
+      await refresh();
+      connectStream();
+    }
+
+    async function startCustomWatch() {
+      const payload = {
+        path: $('customPath').value.trim(),
+        poll_interval: Number($('customPollInterval').value || '0.5'),
+        start_at_end: $('startAtEnd').value === 'true',
+        analyzer: $('customAnalyzer').value,
+      };
+      await request('/watch/start', 'POST', payload);
+      await refresh();
+      connectStream();
+    }
+
+    async function stopWatch() {
+      await request('/watch/stop', 'POST', {});
+      await refresh();
+    }
+
+    $('startImportButton').addEventListener('click', () => startImportWatch().catch((error) => alert(error.message)));
+    $('startCustomButton').addEventListener('click', () => startCustomWatch().catch((error) => alert(error.message)));
+    $('stopButton').addEventListener('click', () => stopWatch().catch((error) => alert(error.message)));
+    $('refreshButton').addEventListener('click', () => refresh().catch((error) => alert(error.message)));
+
+    connectStream();
+    refresh();
+    setInterval(() => refresh().catch(() => {}), 5000);
+  </script>
+</body>
+</html>
+"""
 
 
 def _stream_pipe(pipe, level, prefix, output_buffer, state):
@@ -167,6 +960,7 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
 # ---------------------------------------------------------------------------
 
 class CompanionHandler(BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
 
     def log_message(self, fmt, *args):
         """Route access log through the standard logger."""
@@ -177,33 +971,49 @@ class CompanionHandler(BaseHTTPRequestHandler):
     # ------------------------------------------------------------------
 
     def do_GET(self):
-        if self.path == "/health":
+        path = urllib.parse.urlparse(self.path).path
+        if path == "/health":
             self._handle_health()
-        elif self.path == "/pending":
+        elif path == "/pending":
             self._handle_pending_get()
-        elif self.path == "/webviewer/status":
+        elif path == "/watch/status":
+            self._handle_watch_status()
+        elif path == "/watch/results":
+            self._handle_watch_results()
+        elif path == "/watch/stream":
+            self._handle_watch_stream()
+        elif path == "/watch/ui":
+            self._handle_watch_ui()
+        elif path == "/webviewer/status":
             self._handle_webviewer_status()
         else:
             self._send_json({"error": "Not found"}, status=404)
 
     def do_POST(self):
-        if self.path == "/explode":
+        path = urllib.parse.urlparse(self.path).path
+        if path == "/explode":
             self._handle_explode()
-        elif self.path == "/context":
+        elif path == "/context":
             self._handle_context()
-        elif self.path == "/debug":
+        elif path == "/debug":
             self._handle_debug()
-        elif self.path == "/clipboard":
+        elif path == "/clipboard":
             self._handle_clipboard()
-        elif self.path == "/trigger":
+        elif path == "/trigger":
             self._handle_trigger()
-        elif self.path == "/pending":
+        elif path == "/pending":
             self._handle_pending_post()
-        elif self.path == "/webviewer/start":
+        elif path == "/watch/start":
+            self._handle_watch_start()
+        elif path == "/watch/import-log/start":
+            self._handle_watch_import_log_start()
+        elif path == "/watch/stop":
+            self._handle_watch_stop()
+        elif path == "/webviewer/start":
             self._handle_webviewer_start()
-        elif self.path == "/webviewer/stop":
+        elif path == "/webviewer/stop":
             self._handle_webviewer_stop()
-        elif self.path == "/webviewer/push":
+        elif path == "/webviewer/push":
             self._handle_webviewer_push()
         elif self.path == "/lint":
             self._handle_lint()
@@ -216,6 +1026,139 @@ class CompanionHandler(BaseHTTPRequestHandler):
 
     def _handle_health(self):
         self._send_json({"status": "ok", "version": VERSION})
+
+    def _handle_watch_status(self):
+        self._send_json(_snapshot_file_watch_state())
+
+    def _handle_watch_results(self):
+        self._send_json(_current_watch_results_payload())
+
+    def _handle_watch_stream(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/event-stream; charset=utf-8")
+        self.send_header("Cache-Control", "no-cache")
+        self.send_header("Connection", "keep-alive")
+        self.end_headers()
+
+        last_revision = -1
+        try:
+            while True:
+                with _file_watch_lock:
+                    current_revision = _file_watch_state.get("revision", 0)
+                    if current_revision == last_revision:
+                        _file_watch_condition.wait(timeout=15)
+                        current_revision = _file_watch_state.get("revision", 0)
+                    payload = _watch_results_payload_from_state(_clone_jsonable(_file_watch_state))
+
+                if current_revision == last_revision:
+                    self._send_sse_event("ping", {"timestamp": _utc_now_iso()})
+                    continue
+
+                self._send_sse_event("results", payload, event_id=current_revision)
+                last_revision = current_revision
+        except (BrokenPipeError, ConnectionResetError, TimeoutError, socket.timeout, OSError):
+            return
+
+    def _handle_watch_ui(self):
+        self._send_html(_build_watch_ui_html())
+
+    def _handle_watch_start(self):
+        try:
+            body = self._read_body()
+            payload = json.loads(body) if body else {}
+        except (ValueError, OSError) as exc:
+            self._send_json({"success": False, "error": f"Invalid request: {exc}"}, status=400)
+            return
+
+        path = payload.get("path", "")
+        if not path:
+            self._send_json({"success": False, "error": "Missing required field: path"}, status=400)
+            return
+
+        try:
+            poll_interval = float(payload.get("poll_interval", FILE_WATCH_POLL_INTERVAL_SECONDS))
+        except (TypeError, ValueError):
+            self._send_json({"success": False, "error": "poll_interval must be a number"}, status=400)
+            return
+
+        if poll_interval <= 0:
+            self._send_json({"success": False, "error": "poll_interval must be greater than 0"}, status=400)
+            return
+
+        start_at_end = bool(payload.get("start_at_end", True))
+
+        try:
+            analyzer_config = _normalize_analyzer_config(payload.get("analyzer"))
+            state = _start_file_watch(path, poll_interval, start_at_end, analyzer_config)
+        except ValueError as exc:
+            self._send_json({"success": False, "error": str(exc)}, status=400)
+            return
+        except Exception as exc:
+            log.exception("Failed to start file watch: %s", exc)
+            self._send_json({"success": False, "error": str(exc)}, status=500)
+            return
+
+        log.info(
+            "File watch started: path=%s analyzer=%s poll_interval=%ss start_at_end=%s",
+            state["path"],
+            state["analyzer"]["type"],
+            state["poll_interval"],
+            state["start_at_end"],
+        )
+        self._send_json({"success": True, "watch": state})
+
+    def _handle_watch_import_log_start(self):
+        try:
+            body = self._read_body()
+            payload = json.loads(body) if body else {}
+        except (ValueError, OSError) as exc:
+            self._send_json({"success": False, "error": f"Invalid request: {exc}"}, status=400)
+            return
+
+        try:
+            poll_interval = float(payload.get("poll_interval", FILE_WATCH_POLL_INTERVAL_SECONDS))
+        except (TypeError, ValueError):
+            self._send_json({"success": False, "error": "poll_interval must be a number"}, status=400)
+            return
+
+        if poll_interval <= 0:
+            self._send_json({"success": False, "error": "poll_interval must be greater than 0"}, status=400)
+            return
+
+        start_at_end = bool(payload.get("start_at_end", True))
+
+        try:
+            resolved = _resolve_import_log_path(payload)
+            analyzer_config = _normalize_analyzer_config(payload.get("analyzer", "import_log_unknown_attributes"))
+            state = _start_file_watch(resolved["path"], poll_interval, start_at_end, analyzer_config)
+        except ValueError as exc:
+            self._send_json({"success": False, "error": str(exc)}, status=400)
+            return
+        except Exception as exc:
+            log.exception("Failed to start Import.log watch: %s", exc)
+            self._send_json({"success": False, "error": str(exc)}, status=500)
+            return
+
+        log.info(
+            "Import.log watch started: location=%s path=%s analyzer=%s",
+            resolved["location"],
+            state["path"],
+            state["analyzer"]["type"],
+        )
+        self._send_json(
+            {
+                "success": True,
+                "location": resolved["location"],
+                "resolved_path": state["path"],
+                "watch": state,
+            }
+        )
+
+    def _handle_watch_stop(self):
+        was_running = _stop_file_watch()
+        if was_running:
+            log.info("File watch stopped")
+        self._send_json({"success": True, "status": "stopped" if was_running else "not_running"})
 
     def _handle_explode(self):
         # Read and parse request body
@@ -704,6 +1647,30 @@ class CompanionHandler(BaseHTTPRequestHandler):
         self.end_headers()
         self.wfile.write(body)
 
+    def _send_html(self, html_body: str, status: int = 200):
+        body = html_body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _send_sse_event(self, event_name: str, data, event_id=None):
+        if isinstance(data, str):
+            payload = data
+        else:
+            payload = json.dumps(data, ensure_ascii=False)
+        chunks = []
+        if event_id is not None:
+            chunks.append(f"id: {event_id}\n")
+        if event_name:
+            chunks.append(f"event: {event_name}\n")
+        for line in payload.splitlines() or [""]:
+            chunks.append(f"data: {line}\n")
+        chunks.append("\n")
+        self.wfile.write("".join(chunks).encode("utf-8"))
+        self.wfile.flush()
+
 
 # ---------------------------------------------------------------------------
 # Entry point
@@ -752,13 +1719,14 @@ def main():
 
     log.info("companion_server v%s listening on %s:%d", VERSION, BIND_HOST, port)
     threading.Thread(target=_check_for_updates, daemon=True).start()
-    log.info("Endpoints: GET /health  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
+    log.info("Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
     log.info("Press Ctrl-C to stop.")
 
     try:
         server.serve_forever()
     except KeyboardInterrupt:
         log.info("Shutting down.")
+        _stop_file_watch()
         server.server_close()
         with _webviewer_lock:
             if _webviewer_proc is not None and _webviewer_proc.poll() is None:

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import logging
 import os
+import platform
 import re
 import signal
 import socket
@@ -136,6 +137,180 @@ def _clone_jsonable(data):
     return json.loads(json.dumps(data, ensure_ascii=False))
 
 
+def _default_documents_dir() -> str:
+    if sys.platform == "win32":
+        try:
+            import ctypes
+            from ctypes import wintypes
+
+            buffer = ctypes.create_unicode_buffer(wintypes.MAX_PATH)
+            result = ctypes.windll.shell32.SHGetFolderPathW(None, 5, None, 0, buffer)
+            if result == 0 and buffer.value:
+                return buffer.value
+        except Exception:
+            pass
+
+        user_profile = os.environ.get("USERPROFILE", "")
+        if user_profile:
+            return os.path.join(user_profile, "Documents")
+
+    return os.path.expanduser("~/Documents")
+
+
+def _split_initial_path(initial_path: str) -> tuple[str, str]:
+    initial_path = os.path.expanduser(initial_path or "")
+    initial_dir = ""
+    initial_file = ""
+    if initial_path:
+        if os.path.isdir(initial_path):
+            initial_dir = initial_path
+        else:
+            initial_dir = os.path.dirname(initial_path)
+            initial_file = os.path.basename(initial_path)
+    return initial_dir, initial_file
+
+
+def _open_path_dialog_tk(selection_type: str, initial_path: str = "", title: str = "") -> str:
+    import tkinter as tk
+    from tkinter import filedialog
+
+    initial_dir, initial_file = _split_initial_path(initial_path)
+
+    root = tk.Tk()
+    root.withdraw()
+    try:
+        root.attributes("-topmost", True)
+    except Exception:
+        pass
+    root.update()
+
+    try:
+        if selection_type == "directory":
+            selected_path = filedialog.askdirectory(
+                title=title or "Select folder",
+                initialdir=initial_dir or _default_documents_dir(),
+                parent=root,
+                mustexist=True,
+            )
+        elif selection_type == "file":
+            selected_path = filedialog.askopenfilename(
+                title=title or "Select file",
+                initialdir=initial_dir or _default_documents_dir(),
+                initialfile=initial_file,
+                parent=root,
+                filetypes=[
+                    ("Log and FileMaker files", "*.log *.fmp12"),
+                    ("All files", "*"),
+                ],
+            )
+        else:
+            raise ValueError("selection_type must be file or directory")
+    finally:
+        root.destroy()
+
+    return selected_path or ""
+
+
+def _apple_script_quote(value: str) -> str:
+    return str(value or "").replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _open_path_dialog_macos(selection_type: str, initial_path: str = "", title: str = "") -> str:
+    initial_dir, _ = _split_initial_path(initial_path)
+    if not initial_dir:
+        initial_dir = _default_documents_dir()
+
+    location_clause = ""
+    if initial_dir and os.path.exists(initial_dir):
+        location_clause = f' default location (POSIX file "{_apple_script_quote(initial_dir)}")'
+
+    prompt = _apple_script_quote(title or ("Select folder" if selection_type == "directory" else "Select file"))
+    if selection_type == "directory":
+        choose_stmt = f'set chosenItem to choose folder with prompt "{prompt}"{location_clause}'
+    elif selection_type == "file":
+        choose_stmt = f'set chosenItem to choose file with prompt "{prompt}"{location_clause}'
+    else:
+        raise ValueError("selection_type must be file or directory")
+
+    script = "\n".join(
+        [
+            "try",
+            f"    {choose_stmt}",
+            "    return POSIX path of chosenItem",
+            "on error number -128",
+            '    return ""',
+            "end try",
+        ]
+    )
+    result = subprocess.run(
+        ["osascript", "-e", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_message = (result.stderr or result.stdout or "osascript path picker failed").strip()
+        raise RuntimeError(error_message)
+    return (result.stdout or "").strip()
+
+
+def _powershell_single_quote(value: str) -> str:
+    return str(value or "").replace("'", "''")
+
+
+def _open_path_dialog_windows(selection_type: str, initial_path: str = "", title: str = "") -> str:
+    initial_dir, initial_file = _split_initial_path(initial_path)
+    if not initial_dir:
+        initial_dir = _default_documents_dir()
+
+    if selection_type == "file":
+        script = "\n".join(
+            [
+                "Add-Type -AssemblyName System.Windows.Forms",
+                "$dialog = New-Object System.Windows.Forms.OpenFileDialog",
+                f"$dialog.Title = '{_powershell_single_quote(title or 'Select file')}'",
+                f"$dialog.InitialDirectory = '{_powershell_single_quote(initial_dir)}'",
+                f"$dialog.FileName = '{_powershell_single_quote(initial_file)}'",
+                "$dialog.Filter = 'Log and FileMaker files (*.log;*.fmp12)|*.log;*.fmp12|All files (*.*)|*.*'",
+                "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.FileName }",
+            ]
+        )
+    elif selection_type == "directory":
+        script = "\n".join(
+            [
+                "Add-Type -AssemblyName System.Windows.Forms",
+                "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
+                f"$dialog.Description = '{_powershell_single_quote(title or 'Select folder')}'",
+                f"$dialog.SelectedPath = '{_powershell_single_quote(initial_dir)}'",
+                "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) { Write-Output $dialog.SelectedPath }",
+            ]
+        )
+    else:
+        raise ValueError("selection_type must be file or directory")
+
+    result = subprocess.run(
+        ["powershell", "-NoProfile", "-STA", "-Command", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        error_message = (result.stderr or result.stdout or "PowerShell path picker failed").strip()
+        raise RuntimeError(error_message)
+    return (result.stdout or "").strip()
+
+
+def _open_path_dialog(selection_type: str, initial_path: str = "", title: str = "") -> str:
+    try:
+        return _open_path_dialog_tk(selection_type, initial_path=initial_path, title=title)
+    except (ImportError, ModuleNotFoundError):
+        if sys.platform == "darwin":
+            return _open_path_dialog_macos(selection_type, initial_path=initial_path, title=title)
+        if sys.platform == "win32":
+            return _open_path_dialog_windows(selection_type, initial_path=initial_path, title=title)
+        raise RuntimeError("No native path picker available on this Python installation. Enter the path manually.")
+
+
 def _new_file_watch_summary() -> dict:
     return {
         "events_total": 0,
@@ -172,6 +347,13 @@ def _watch_results_payload_from_state(state: dict) -> dict:
         "last_change_at": state["last_change_at"],
         "last_event_at": state["last_event_at"],
         "last_error": state["last_error"],
+        "platform": {
+            "system": platform.system(),
+            "python_platform": sys.platform,
+        },
+        "defaults": {
+            "documents_dir": _default_documents_dir(),
+        },
     }
 
 
@@ -807,7 +989,7 @@ def _resolve_import_log_path(payload: dict) -> dict:
         location = "local" if database_path or database_dir else "server"
 
     if location == "server":
-        documents_dir = os.path.expanduser(payload.get("documents_dir", "~/Documents"))
+        documents_dir = os.path.expanduser(payload.get("documents_dir") or _default_documents_dir())
         return {
             "location": "server",
             "path": os.path.join(documents_dir, "Import.log"),
@@ -927,6 +1109,12 @@ class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
     """HTTPServer with thread-per-request concurrency."""
     daemon_threads = True
 
+    def handle_error(self, request, client_address):
+        error = sys.exc_info()[1]
+        if isinstance(error, (BrokenPipeError, ConnectionResetError)):
+            return
+        super().handle_error(request, client_address)
+
 
 # ---------------------------------------------------------------------------
 # Request handler
@@ -980,6 +1168,8 @@ class CompanionHandler(BaseHTTPRequestHandler):
             self._handle_watch_start()
         elif path == "/watch/import-log/start":
             self._handle_watch_import_log_start()
+        elif path == "/watch/pick-path":
+            self._handle_watch_pick_path()
         elif path == "/watch/stop":
             self._handle_watch_stop()
         elif path == "/webviewer/start":
@@ -1130,7 +1320,41 @@ class CompanionHandler(BaseHTTPRequestHandler):
             }
         )
 
+    def _handle_watch_pick_path(self):
+        try:
+            body = self._read_body()
+            payload = json.loads(body) if body else {}
+        except (ValueError, OSError) as exc:
+            self._send_json({"success": False, "error": f"Invalid request: {exc}"}, status=400)
+            return
+
+        selection_type = str(payload.get("selection_type", "file") or "file").strip().lower()
+        initial_path = str(payload.get("initial_path", "") or "")
+        title = str(payload.get("title", "") or "")
+
+        try:
+            selected_path = _open_path_dialog(selection_type, initial_path=initial_path, title=title)
+        except ValueError as exc:
+            self._send_json({"success": False, "error": str(exc)}, status=400)
+            return
+        except Exception as exc:
+            log.exception("Failed to open watch path picker: %s", exc)
+            self._send_json({"success": False, "error": str(exc)}, status=500)
+            return
+
+        self._send_json(
+            {
+                "success": True,
+                "selected_path": selected_path,
+                "cancelled": not bool(selected_path),
+            }
+        )
+
     def _handle_watch_stop(self):
+        try:
+            self._read_body()
+        except OSError:
+            pass
         was_running = _stop_file_watch()
         if was_running:
             log.info("File watch stopped")

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -1911,15 +1911,28 @@ def parse_args():
     return parser.parse_args()
 
 
+def _format_local_url(host: str, port: int, path: str = "") -> str:
+    display_host = (host or "127.0.0.1").strip()
+    if display_host in {"0.0.0.0", "::", ""}:
+        display_host = "127.0.0.1"
+    if ":" in display_host and not display_host.startswith("["):
+        display_host = f"[{display_host}]"
+    normalized_path = path if path.startswith("/") or not path else f"/{path}"
+    return f"http://{display_host}:{port}{normalized_path}"
+
+
 def main():
     args = parse_args()
-    port = args.port
+    requested_port = args.port
 
-    server = ThreadingHTTPServer((BIND_HOST, port), CompanionHandler)
+    server = ThreadingHTTPServer((BIND_HOST, requested_port), CompanionHandler)
+    actual_port = int(server.server_address[1])
+    watch_ui_url = _format_local_url(BIND_HOST, actual_port, "/watch/ui")
 
-    log.info("companion_server v%s listening on %s:%d", VERSION, BIND_HOST, port)
+    log.info("companion_server v%s listening on %s:%d", VERSION, BIND_HOST, actual_port)
+    log.info("Watch UI: %s", watch_ui_url)
     threading.Thread(target=_check_for_updates, daemon=True).start()
-    log.info("Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
+    log.info("Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
     log.info("Press Ctrl-C to stop.")
 
     try:

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -396,6 +396,51 @@ def _classify_import_log_issue(parsed: dict) -> dict:
     }
 
 
+def _import_issue_label(issue: dict) -> str:
+    labels = {
+        "unknown_attribute_value": "Unknown attribute value",
+        "missing_attribute": "Missing attribute",
+        "missing_field": "Missing field",
+        "missing_field_reference": "Missing field reference",
+        "missing_layout": "Missing layout",
+        "missing_script": "Missing script",
+        "missing_function": "Missing function",
+        "missing_table_reference": "Missing table reference",
+        "unknown_error": "Unknown error",
+        "other": "Other error",
+    }
+    return labels.get(issue.get("category", "other"), "Import error")
+
+
+def _set_current_import_script_name(current_import: dict, parsed: dict):
+    script_name = str(parsed.get("script_name", "") or "").strip()
+    source = str(parsed.get("source", "") or "").strip()
+    database_name = str(current_import.get("database_name", "") or "").strip()
+    if not script_name and source and "::" not in source and source != database_name:
+        script_name = source
+    if script_name:
+        current_import["script_name"] = script_name
+
+
+def _append_import_error_locked(current_import: dict, parsed: dict, issue: dict):
+    errors = current_import.setdefault("errors", [])
+    errors.append(
+        {
+            "timestamp": parsed["timestamp"],
+            "script_name": parsed.get("script_name", ""),
+            "line_number": parsed.get("script_line", ""),
+            "step_name": parsed.get("step_name", ""),
+            "attribute_name": parsed.get("attribute_name", ""),
+            "code": parsed["code"],
+            "rule": issue["rule"],
+            "category": issue["category"],
+            "label": _import_issue_label(issue),
+            "message": parsed["message"],
+            "raw_line": parsed["raw_line"],
+        }
+    )
+
+
 def _append_recent_import_locked(import_summary: dict):
     recent_imports = _file_watch_state["summary"].setdefault("recent_imports", [])
     recent_imports.append(import_summary)
@@ -415,6 +460,7 @@ def _record_import_lifecycle_event_locked(parsed: dict, rule: str, severity: str
         "message": message if message is not None else parsed["message"],
         "script_name": parsed.get("script_name", ""),
         "script_line": parsed.get("script_line", ""),
+        "line_number": parsed.get("script_line", ""),
         "step_name": parsed.get("step_name", ""),
         "attribute_name": parsed.get("attribute_name", ""),
         "unknown_value": parsed.get("unknown_value", ""),
@@ -440,8 +486,10 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
         if message == "Import of script steps from clipboard started":
             summary["current_import"] = {
                 "source": source,
+                "database_name": source,
                 "started_at": parsed["timestamp"],
                 "error_count": 0,
+                "errors": [],
             }
             events.append(
                 _record_import_lifecycle_event_locked(
@@ -457,9 +505,12 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
             if not current_import:
                 current_import = {
                     "source": source,
+                    "database_name": source,
                     "started_at": parsed["timestamp"],
                     "error_count": 0,
+                    "errors": [],
                 }
+            _set_current_import_script_name(current_import, parsed)
             current_import["imported_steps"] = parsed["imported_steps"]
             summary["current_import"] = current_import
             events.append(
@@ -510,6 +561,11 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
             return events
 
         issue = _classify_import_log_issue(parsed)
+        current_import = summary.get("current_import") or {}
+        if current_import:
+            _set_current_import_script_name(current_import, parsed)
+            _append_import_error_locked(current_import, parsed, issue)
+            summary["current_import"] = current_import
         event = {
             "detected_at": _utc_now_iso(),
             "event_type": "import_log_issue",
@@ -519,9 +575,11 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
             "source": source,
             "code": code,
             "category": issue["category"],
+            "label": _import_issue_label(issue),
             "message": message,
             "script_name": parsed.get("script_name", ""),
             "script_line": parsed.get("script_line", ""),
+            "line_number": parsed.get("script_line", ""),
             "step_name": parsed.get("step_name", ""),
             "attribute_name": parsed.get("attribute_name", ""),
             "unknown_value": parsed.get("unknown_value", ""),
@@ -781,290 +839,9 @@ def _resolve_import_log_path(payload: dict) -> dict:
 
 
 def _build_watch_ui_html() -> str:
-    return """<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Companion Watch</title>
-  <style>
-    :root { color-scheme: dark; }
-    body { margin: 0; font-family: Inter, system-ui, sans-serif; background: #0b1020; color: #e5e7eb; }
-    .wrap { max-width: 1180px; margin: 0 auto; padding: 24px; }
-    .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 16px; }
-    .panel { background: #121933; border: 1px solid #26304f; border-radius: 14px; padding: 16px; box-shadow: 0 10px 30px rgba(0,0,0,.18); }
-    .panel.full { grid-column: 1 / -1; }
-    h1, h2 { margin: 0 0 12px; }
-    h1 { font-size: 24px; }
-    h2 { font-size: 16px; }
-    .muted { color: #93a1c6; }
-    .row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; margin-bottom: 12px; }
-    .row.single { grid-template-columns: 1fr; }
-    label { display: block; font-size: 12px; color: #93a1c6; margin-bottom: 6px; }
-    input, select, button, textarea { width: 100%; box-sizing: border-box; border-radius: 10px; border: 1px solid #334269; background: #0f1530; color: #eef2ff; padding: 10px 12px; font: inherit; }
-    textarea { min-height: 110px; resize: vertical; }
-    button { cursor: pointer; background: linear-gradient(180deg, #4169e1, #3558c8); border: none; font-weight: 600; }
-    button.secondary { background: #1a2342; border: 1px solid #334269; }
-    button.danger { background: linear-gradient(180deg, #c9405e, #a52d48); }
-    .button-row { display: flex; gap: 10px; flex-wrap: wrap; }
-    .badge { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: 999px; background: #1a2342; color: #c7d2fe; font-size: 12px; margin-right: 8px; }
-    .badge.ok { background: #16351e; color: #9ae6b4; }
-    .badge.warn { background: #3a2712; color: #fbd38d; }
-    .badge.err { background: #3d1620; color: #feb2b2; }
-    .kv { display: grid; grid-template-columns: 180px 1fr; gap: 8px; font-size: 13px; }
-    .events { display: grid; gap: 10px; }
-    .event { border: 1px solid #2e395d; border-radius: 12px; padding: 12px; background: #0d1430; }
-    .event.info { border-color: #2f5d8a; }
-    .event.warn { border-color: #8a6a2f; }
-    .event.error { border-color: #7f2940; }
-    .event .meta { color: #93a1c6; font-size: 12px; margin-bottom: 6px; }
-    .event .msg { white-space: pre-wrap; word-break: break-word; }
-    pre { margin: 0; white-space: pre-wrap; word-break: break-word; background: #0d1430; border: 1px solid #2e395d; border-radius: 12px; padding: 12px; }
-    @media (max-width: 900px) { .grid, .row { grid-template-columns: 1fr; } }
-  </style>
-</head>
-<body>
-  <div class="wrap">
-    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px;flex-wrap:wrap;">
-      <div>
-        <h1>Companion Watch</h1>
-        <div class="muted">Live file watch, Import.log auto-resolution, SSE stream, and recent event view.</div>
-      </div>
-      <div>
-        <span id="runningBadge" class="badge">stopped</span>
-        <span id="streamBadge" class="badge">stream idle</span>
-      </div>
-    </div>
-    <div class="grid">
-      <section class="panel">
-        <h2>Auto Import.log Watch</h2>
-        <div class="row">
-          <div>
-            <label for="importLocation">Location</label>
-            <select id="importLocation">
-              <option value="server">Server file</option>
-              <option value="local">Local database file</option>
-            </select>
-          </div>
-          <div>
-            <label for="importAnalyzer">Analyzer</label>
-            <select id="importAnalyzer">
-              <option value="import_log">All Import.log issues</option>
-              <option value="import_log_unknown_attributes">Unknown attributes only</option>
-            </select>
-          </div>
-        </div>
-        <div class="row single">
-          <div>
-            <label for="databasePath">Database path or folder for local file mode</label>
-            <input id="databasePath" placeholder="/path/to/MyFile.fmp12">
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="documentsDir">Documents dir for server mode</label>
-            <input id="documentsDir" value="~/Documents">
-          </div>
-          <div>
-            <label for="importPollInterval">Poll interval</label>
-            <input id="importPollInterval" value="0.5">
-          </div>
-        </div>
-        <div class="button-row">
-          <button id="startImportButton">Start Import.log watch</button>
-        </div>
-      </section>
-      <section class="panel">
-        <h2>Custom File Watch</h2>
-        <div class="row single">
-          <div>
-            <label for="customPath">File path</label>
-            <input id="customPath" placeholder="/path/to/file.log">
-          </div>
-        </div>
-        <div class="row">
-          <div>
-            <label for="customAnalyzer">Analyzer</label>
-            <select id="customAnalyzer">
-              <option value="import_log">Import.log issues</option>
-              <option value="import_log_unknown_attributes">Import.log unknown attributes</option>
-            </select>
-          </div>
-          <div>
-            <label for="customPollInterval">Poll interval</label>
-            <input id="customPollInterval" value="0.5">
-          </div>
-        </div>
-        <div class="row single">
-          <div>
-            <label for="startAtEnd">Start at end of file</label>
-            <select id="startAtEnd">
-              <option value="true">true</option>
-              <option value="false">false</option>
-            </select>
-          </div>
-        </div>
-        <div class="button-row">
-          <button id="startCustomButton">Start custom watch</button>
-          <button id="stopButton" class="danger">Stop watch</button>
-          <button id="refreshButton" class="secondary">Refresh</button>
-        </div>
-      </section>
-      <section class="panel full">
-        <h2>Status</h2>
-        <div id="statusGrid" class="kv"></div>
-      </section>
-      <section class="panel">
-        <h2>Summary</h2>
-        <pre id="summaryView">{}</pre>
-      </section>
-      <section class="panel">
-        <h2>Current / Last Import</h2>
-        <pre id="importView">{}</pre>
-      </section>
-      <section class="panel full">
-        <h2>Recent Events</h2>
-        <div id="events" class="events"></div>
-      </section>
-    </div>
-  </div>
-  <script>
-    const $ = (id) => document.getElementById(id);
-    let stream = null;
-
-    function escapeHtml(value) {
-      return String(value ?? '').replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;');
-    }
-
-    async function request(path, method = 'GET', body = null) {
-      const response = await fetch(path, {
-        method,
-        headers: body ? { 'Content-Type': 'application/json' } : {},
-        body: body ? JSON.stringify(body) : null,
-      });
-      const text = await response.text();
-      const data = text ? JSON.parse(text) : {};
-      if (!response.ok) {
-        throw new Error(data.error || `HTTP ${response.status}`);
-      }
-      return data;
-    }
-
-    function render(state) {
-      const running = Boolean(state.running);
-      $('runningBadge').textContent = running ? 'running' : 'stopped';
-      $('runningBadge').className = `badge ${running ? 'ok' : 'warn'}`;
-      $('statusGrid').innerHTML = [
-        ['Path', state.path || ''],
-        ['File exists', String(Boolean(state.file_exists))],
-        ['Analyzer', state.analyzer?.type || ''],
-        ['Poll interval', String(state.poll_interval ?? '')],
-        ['Started at', state.started_at || ''],
-        ['Last change', state.last_change_at || ''],
-        ['Last event', state.last_event_at || ''],
-        ['Last error', state.last_error || ''],
-        ['Revision', String(state.revision ?? '')],
-      ].map(([key, value]) => `<div class=\"muted\">${escapeHtml(key)}</div><div>${escapeHtml(value)}</div>`).join('');
-
-      $('summaryView').textContent = JSON.stringify(state.summary || {}, null, 2);
-      $('importView').textContent = JSON.stringify({
-        current_import: state.summary?.current_import || {},
-        last_completed_import: state.summary?.last_completed_import || {},
-        recent_imports: state.summary?.recent_imports || [],
-      }, null, 2);
-
-      const events = [...(state.recent_events || [])].reverse();
-      $('events').innerHTML = events.length ? events.map((event) => {
-        const bits = [
-          event.detected_at || '',
-          event.severity || '',
-          event.rule || '',
-          event.code ? `code ${event.code}` : '',
-          event.import_status || '',
-          event.imported_steps ? `steps ${event.imported_steps}` : '',
-          Number.isFinite(event.error_count) ? `errors ${event.error_count}` : '',
-          event.script_name || '',
-          event.source || '',
-          event.script_line || '',
-          event.step_name || '',
-          event.attribute_name || '',
-          event.unknown_value || '',
-        ].filter(Boolean).join(' · ');
-        return `<div class=\"event ${escapeHtml(event.severity || '')}\"><div class=\"meta\">${escapeHtml(bits)}</div><div class=\"msg\">${escapeHtml(event.message || event.raw_line || '')}</div></div>`;
-      }).join('') : '<div class=\"muted\">No events yet.</div>';
-    }
-
-    async function refresh() {
-      try {
-        const state = await request('/watch/results');
-        render(state);
-      } catch (error) {
-        $('streamBadge').textContent = error.message;
-        $('streamBadge').className = 'badge err';
-      }
-    }
-
-    function connectStream() {
-      if (stream) {
-        stream.close();
-      }
-      stream = new EventSource('/watch/stream');
-      $('streamBadge').textContent = 'connecting';
-      $('streamBadge').className = 'badge warn';
-      stream.addEventListener('results', (event) => {
-        $('streamBadge').textContent = 'live';
-        $('streamBadge').className = 'badge ok';
-        render(JSON.parse(event.data));
-      });
-      stream.onerror = () => {
-        $('streamBadge').textContent = 'reconnecting';
-        $('streamBadge').className = 'badge warn';
-      };
-    }
-
-    async function startImportWatch() {
-      const payload = {
-        location: $('importLocation').value,
-        database_path: $('databasePath').value.trim(),
-        documents_dir: $('documentsDir').value.trim(),
-        poll_interval: Number($('importPollInterval').value || '0.5'),
-        analyzer: $('importAnalyzer').value,
-        start_at_end: true,
-      };
-      await request('/watch/import-log/start', 'POST', payload);
-      await refresh();
-      connectStream();
-    }
-
-    async function startCustomWatch() {
-      const payload = {
-        path: $('customPath').value.trim(),
-        poll_interval: Number($('customPollInterval').value || '0.5'),
-        start_at_end: $('startAtEnd').value === 'true',
-        analyzer: $('customAnalyzer').value,
-      };
-      await request('/watch/start', 'POST', payload);
-      await refresh();
-      connectStream();
-    }
-
-    async function stopWatch() {
-      await request('/watch/stop', 'POST', {});
-      await refresh();
-    }
-
-    $('startImportButton').addEventListener('click', () => startImportWatch().catch((error) => alert(error.message)));
-    $('startCustomButton').addEventListener('click', () => startCustomWatch().catch((error) => alert(error.message)));
-    $('stopButton').addEventListener('click', () => stopWatch().catch((error) => alert(error.message)));
-    $('refreshButton').addEventListener('click', () => refresh().catch((error) => alert(error.message)));
-
-    connectStream();
-    refresh();
-    setInterval(() => refresh().catch(() => {}), 5000);
-  </script>
-</body>
-</html>
-"""
+    ui_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "companion_watch_ui.html")
+    with open(ui_path, "r", encoding="utf-8") as f:
+        return f.read()
 
 
 def _stream_pipe(pipe, level, prefix, output_buffer, state):

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -1164,8 +1164,6 @@ class CompanionHandler(BaseHTTPRequestHandler):
             self._handle_trigger()
         elif path == "/pending":
             self._handle_pending_post()
-        elif path == "/watch/start":
-            self._handle_watch_start()
         elif path == "/watch/import-log/start":
             self._handle_watch_import_log_start()
         elif path == "/watch/pick-path":
@@ -1224,54 +1222,6 @@ class CompanionHandler(BaseHTTPRequestHandler):
 
     def _handle_watch_ui(self):
         self._send_html(_build_watch_ui_html())
-
-    def _handle_watch_start(self):
-        try:
-            body = self._read_body()
-            payload = json.loads(body) if body else {}
-        except (ValueError, OSError) as exc:
-            self._send_json(
-                {"success": False, "exit_code": -1, "error": f"Invalid request: {exc}"},
-                status=400,
-            )
-            return
-
-        path = payload.get("path", "")
-        if not path:
-            self._send_json({"success": False, "exit_code": -1, "error": "Missing required field: path"}, status=400)
-            return
-
-        try:
-            poll_interval = float(payload.get("poll_interval", FILE_WATCH_POLL_INTERVAL_SECONDS))
-        except (TypeError, ValueError):
-            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be a number"}, status=400)
-            return
-
-        if poll_interval <= 0:
-            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be greater than 0"}, status=400)
-            return
-
-        start_at_end = bool(payload.get("start_at_end", True))
-
-        try:
-            analyzer_config = _normalize_analyzer_config(payload.get("analyzer"))
-            state = _start_file_watch(path, poll_interval, start_at_end, analyzer_config)
-        except ValueError as exc:
-            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=400)
-            return
-        except Exception as exc:
-            log.exception("Failed to start file watch: %s", exc)
-            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=500)
-            return
-
-        log.info(
-            "File watch started: path=%s analyzer=%s poll_interval=%ss start_at_end=%s",
-            state["path"],
-            state["analyzer"]["type"],
-            state["poll_interval"],
-            state["start_at_end"],
-        )
-        self._send_json({"success": True, "watch": state})
 
     def _handle_watch_import_log_start(self):
         try:
@@ -1932,7 +1882,7 @@ def main():
     log.info("companion_server v%s listening on %s:%d", VERSION, BIND_HOST, actual_port)
     log.info("Watch UI: %s", watch_ui_url)
     threading.Thread(target=_check_for_updates, daemon=True).start()
-    log.info("Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/start  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
+    log.info("Endpoints: GET /health  GET /pending  GET /watch/status  GET /watch/results  GET /watch/stream  GET /watch/ui  GET /webviewer/status  POST /explode  POST /context  POST /clipboard  POST /trigger  POST /debug  POST /pending  POST /watch/import-log/start  POST /watch/pick-path  POST /watch/stop  POST /webviewer/start  POST /webviewer/stop  POST /webviewer/push")
     log.info("Press Ctrl-C to stop.")
 
     try:

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -43,7 +43,17 @@ BIND_HOST = os.environ.get("COMPANION_BIND_HOST", "127.0.0.1")
 REMOTE_VERSION_URL = "https://raw.githubusercontent.com/petrowsky/agentic-fm/main/version.txt"
 FILE_WATCH_POLL_INTERVAL_SECONDS = 0.5
 FILE_WATCH_MAX_EVENTS = 100
+FILE_WATCH_MAX_IMPORTS = 20
+IMPORT_LOG_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2} ")
 IMPORT_LOG_UNKNOWN_VALUE_RE = re.compile(r'Attribute value [“"](.+?)[”"] unknown\.')
+IMPORT_LOG_ATTRIBUTE_MISSING_RE = re.compile(r'^Attribute [“"](.+?)[”"] missing\.$')
+IMPORT_LOG_FIELD_MISSING_RE = re.compile(r'^Field [“"](.+?)[”"] missing\.$')
+IMPORT_LOG_FIELD_REFERENCE_MISSING_RE = re.compile(r'^Field referred to in the calculation [“"](.+?)[”"] is missing\.$', re.S)
+IMPORT_LOG_LAYOUT_MISSING_RE = re.compile(r'^Layout [“"](.+?)[”"] missing\.$')
+IMPORT_LOG_SCRIPT_MISSING_RE = re.compile(r'^Script [“"](.+?)[”"] missing\.$')
+IMPORT_LOG_FUNCTION_MISSING_RE = re.compile(r'^Function referred to in the calculation [“"](.+?)[”"] is missing\.$', re.S)
+IMPORT_LOG_TABLE_MISSING_RE = re.compile(r'^Table referred to in the calculation [“"](.+?)[”"] is missing\.$', re.S)
+IMPORT_LOG_UNKNOWN_ERROR_RE = re.compile(r'^Unknown Error: <unknown>\.$', re.I)
 
 # Read version from version.txt at the repo root
 def _read_local_version() -> str:
@@ -91,8 +101,13 @@ _file_watch_state: dict = {
         "events_total": 0,
         "errors_total": 0,
         "matches_by_rule": {},
+        "errors_by_code": {},
         "current_import": {},
         "last_completed_import": {},
+        "recent_imports": [],
+        "imports_total": 0,
+        "imports_with_errors": 0,
+        "imports_without_errors": 0,
         "last_error": {},
     },
     "recent_events": [],
@@ -119,6 +134,22 @@ def _utc_now_iso() -> str:
 
 def _clone_jsonable(data):
     return json.loads(json.dumps(data, ensure_ascii=False))
+
+
+def _new_file_watch_summary() -> dict:
+    return {
+        "events_total": 0,
+        "errors_total": 0,
+        "matches_by_rule": {},
+        "errors_by_code": {},
+        "current_import": {},
+        "last_completed_import": {},
+        "recent_imports": [],
+        "imports_total": 0,
+        "imports_with_errors": 0,
+        "imports_without_errors": 0,
+        "last_error": {},
+    }
 
 
 def _snapshot_file_watch_state() -> dict:
@@ -230,6 +261,9 @@ def _record_watch_event_locked(event: dict):
     if event.get("severity") == "error":
         summary["errors_total"] += 1
         summary["last_error"] = event
+        code = str(event.get("code", "")).strip()
+        if code:
+            summary["errors_by_code"][code] = summary["errors_by_code"].get(code, 0) + 1
         current_import = summary.get("current_import") or {}
         if current_import:
             current_import["error_count"] = int(current_import.get("error_count", 0)) + 1
@@ -250,7 +284,10 @@ def _parse_import_log_line(line: str) -> dict | None:
     if len(parts) != 4:
         return None
 
-    timestamp_str, source, code, message = parts
+    timestamp_str, source, code, message = (part.strip() for part in parts)
+    if not IMPORT_LOG_TIMESTAMP_RE.match(timestamp_str):
+        return None
+
     parsed = {
         "timestamp": timestamp_str,
         "source": source,
@@ -280,6 +317,114 @@ def _parse_import_log_line(line: str) -> dict | None:
     return parsed
 
 
+def _classify_import_log_issue(parsed: dict) -> dict:
+    message = parsed["message"]
+    code = parsed["code"]
+
+    if "unknown_value" in parsed:
+        return {
+            "rule": "unknown_attribute_value",
+            "category": "unknown_attribute_value",
+            "attribute_value": parsed.get("unknown_value", ""),
+        }
+
+    attribute_missing_match = IMPORT_LOG_ATTRIBUTE_MISSING_RE.match(message)
+    if attribute_missing_match:
+        return {
+            "rule": "missing_attribute",
+            "category": "missing_attribute",
+            "attribute_name": attribute_missing_match.group(1),
+        }
+
+    field_missing_match = IMPORT_LOG_FIELD_MISSING_RE.match(message)
+    if field_missing_match:
+        return {
+            "rule": "missing_field",
+            "category": "missing_field",
+            "field_name": field_missing_match.group(1),
+        }
+
+    field_reference_missing_match = IMPORT_LOG_FIELD_REFERENCE_MISSING_RE.match(message)
+    if field_reference_missing_match:
+        return {
+            "rule": "missing_field_reference",
+            "category": "missing_field_reference",
+            "field_reference": field_reference_missing_match.group(1),
+        }
+
+    layout_missing_match = IMPORT_LOG_LAYOUT_MISSING_RE.match(message)
+    if layout_missing_match:
+        return {
+            "rule": "missing_layout",
+            "category": "missing_layout",
+            "layout_name": layout_missing_match.group(1),
+        }
+
+    script_missing_match = IMPORT_LOG_SCRIPT_MISSING_RE.match(message)
+    if script_missing_match:
+        return {
+            "rule": "missing_script",
+            "category": "missing_script",
+            "script_reference": script_missing_match.group(1),
+        }
+
+    function_missing_match = IMPORT_LOG_FUNCTION_MISSING_RE.match(message)
+    if function_missing_match:
+        return {
+            "rule": "missing_function",
+            "category": "missing_function",
+            "function_reference": function_missing_match.group(1),
+        }
+
+    table_missing_match = IMPORT_LOG_TABLE_MISSING_RE.match(message)
+    if table_missing_match:
+        return {
+            "rule": "missing_table_reference",
+            "category": "missing_table_reference",
+            "table_reference": table_missing_match.group(1),
+        }
+
+    if IMPORT_LOG_UNKNOWN_ERROR_RE.match(message):
+        return {
+            "rule": "unknown_error",
+            "category": "unknown_error",
+        }
+
+    return {
+        "rule": f"import_log_code_{code}",
+        "category": "other",
+    }
+
+
+def _append_recent_import_locked(import_summary: dict):
+    recent_imports = _file_watch_state["summary"].setdefault("recent_imports", [])
+    recent_imports.append(import_summary)
+    if len(recent_imports) > FILE_WATCH_MAX_IMPORTS:
+        _file_watch_state["summary"]["recent_imports"] = recent_imports[-FILE_WATCH_MAX_IMPORTS:]
+
+
+def _record_import_lifecycle_event_locked(parsed: dict, rule: str, severity: str, message: str | None = None, **extra) -> dict:
+    event = {
+        "detected_at": _utc_now_iso(),
+        "event_type": "import_log_lifecycle",
+        "rule": rule,
+        "severity": severity,
+        "timestamp": parsed["timestamp"],
+        "source": parsed["source"],
+        "code": parsed["code"],
+        "message": message if message is not None else parsed["message"],
+        "script_name": parsed.get("script_name", ""),
+        "script_line": parsed.get("script_line", ""),
+        "step_name": parsed.get("step_name", ""),
+        "attribute_name": parsed.get("attribute_name", ""),
+        "unknown_value": parsed.get("unknown_value", ""),
+        "raw_line": parsed["raw_line"],
+    }
+    event.update(extra)
+    _record_watch_event_locked(event)
+    return event
+
+
 def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
     parsed = _parse_import_log_line(line)
     if not parsed:
@@ -291,7 +436,6 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
         message = parsed["message"]
         code = parsed["code"]
         source = parsed["source"]
-        state_changed = False
 
         if message == "Import of script steps from clipboard started":
             summary["current_import"] = {
@@ -299,40 +443,82 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
                 "started_at": parsed["timestamp"],
                 "error_count": 0,
             }
-            state_changed = True
+            events.append(
+                _record_import_lifecycle_event_locked(
+                    parsed,
+                    "import_started",
+                    "info",
+                    import_status="running",
+                )
+            )
 
         if "imported_steps" in parsed:
             current_import = summary.get("current_import") or {}
+            if not current_import:
+                current_import = {
+                    "source": source,
+                    "started_at": parsed["timestamp"],
+                    "error_count": 0,
+                }
             current_import["imported_steps"] = parsed["imported_steps"]
             summary["current_import"] = current_import
-            state_changed = True
+            events.append(
+                _record_import_lifecycle_event_locked(
+                    parsed,
+                    "import_steps_imported",
+                    "info",
+                    import_status="running",
+                    imported_steps=parsed["imported_steps"],
+                )
+            )
 
         if message == "Import completed":
             current_import = dict(summary.get("current_import") or {})
+            completed_import = {}
             if current_import:
                 current_import["completed_at"] = parsed["timestamp"]
+                current_import["status"] = "with_errors" if int(current_import.get("error_count", 0)) > 0 else "ok"
                 summary["last_completed_import"] = current_import
+                summary["imports_total"] = int(summary.get("imports_total", 0)) + 1
+                if current_import["status"] == "with_errors":
+                    summary["imports_with_errors"] = int(summary.get("imports_with_errors", 0)) + 1
+                else:
+                    summary["imports_without_errors"] = int(summary.get("imports_without_errors", 0)) + 1
+                _append_recent_import_locked(current_import)
+                completed_import = current_import
             summary["current_import"] = {}
-            state_changed = True
-
-        if state_changed:
-            _bump_file_watch_revision_locked()
+            events.append(
+                _record_import_lifecycle_event_locked(
+                    parsed,
+                    "import_completed",
+                    "warn" if int(completed_import.get("error_count", 0)) > 0 else "info",
+                    message=(
+                        f"Import completed with {int(completed_import.get('error_count', 0))} errors."
+                        if completed_import
+                        else "Import completed."
+                    ),
+                    import_status=completed_import.get("status", "unknown"),
+                    imported_steps=completed_import.get("imported_steps"),
+                    error_count=int(completed_import.get("error_count", 0)),
+                )
+            )
 
         if code == "0":
-            return []
+            return events
 
         if analyzer_type == "import_log_unknown_attributes" and "unknown_value" not in parsed:
-            return []
+            return events
 
-        rule_name = "unknown_attribute" if "unknown_value" in parsed else "import_log_error"
+        issue = _classify_import_log_issue(parsed)
         event = {
             "detected_at": _utc_now_iso(),
             "event_type": "import_log_issue",
-            "rule": rule_name,
+            "rule": issue["rule"],
             "severity": "error",
             "timestamp": parsed["timestamp"],
             "source": source,
             "code": code,
+            "category": issue["category"],
             "message": message,
             "script_name": parsed.get("script_name", ""),
             "script_line": parsed.get("script_line", ""),
@@ -341,6 +527,7 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
             "unknown_value": parsed.get("unknown_value", ""),
             "raw_line": parsed["raw_line"],
         }
+        event.update(issue)
         _record_watch_event_locked(event)
         events.append(event)
 
@@ -370,14 +557,21 @@ def _process_regex_line(line: str, analyzer_runtime: dict) -> list[dict]:
 
 def _process_watch_lines(lines: list[str], analyzer_runtime: dict) -> list[dict]:
     events = []
+    import_log_lines = []
     for line in lines:
         stripped = line.rstrip("\r\n")
         if not stripped:
             continue
         if analyzer_runtime["type"] in ("import_log", "import_log_unknown_attributes"):
-            events.extend(_process_import_log_line(stripped, analyzer_runtime["type"]))
+            if _parse_import_log_line(stripped):
+                import_log_lines.append(stripped)
+            elif import_log_lines:
+                import_log_lines[-1] = f"{import_log_lines[-1]}\n{stripped}"
         elif analyzer_runtime["type"] == "regex":
             events.extend(_process_regex_line(stripped, analyzer_runtime))
+    if analyzer_runtime["type"] in ("import_log", "import_log_unknown_attributes"):
+        for import_log_line in import_log_lines:
+            events.extend(_process_import_log_line(import_log_line, analyzer_runtime["type"]))
     return events
 
 
@@ -531,14 +725,7 @@ def _start_file_watch(path: str, poll_interval: float, start_at_end: bool, analy
         _file_watch_state["file_exists"] = os.path.exists(expanded_path)
         _file_watch_state["revision"] = 0
         _file_watch_state["analyzer"] = _clone_jsonable(analyzer_config)
-        _file_watch_state["summary"] = {
-            "events_total": 0,
-            "errors_total": 0,
-            "matches_by_rule": {},
-            "current_import": {},
-            "last_completed_import": {},
-            "last_error": {},
-        }
+        _file_watch_state["summary"] = _new_file_watch_summary()
         _file_watch_state["recent_events"] = []
         _file_watch_state["last_error"] = ""
         _bump_file_watch_revision_locked()
@@ -595,10 +782,10 @@ def _resolve_import_log_path(payload: dict) -> dict:
 
 def _build_watch_ui_html() -> str:
     return """<!doctype html>
-<html lang=\"en\">
+<html lang="en">
 <head>
-  <meta charset=\"utf-8\">
-  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Companion Watch</title>
   <style>
     :root { color-scheme: dark; }
@@ -627,6 +814,8 @@ def _build_watch_ui_html() -> str:
     .kv { display: grid; grid-template-columns: 180px 1fr; gap: 8px; font-size: 13px; }
     .events { display: grid; gap: 10px; }
     .event { border: 1px solid #2e395d; border-radius: 12px; padding: 12px; background: #0d1430; }
+    .event.info { border-color: #2f5d8a; }
+    .event.warn { border-color: #8a6a2f; }
     .event.error { border-color: #7f2940; }
     .event .meta { color: #93a1c6; font-size: 12px; margin-bottom: 6px; }
     .event .msg { white-space: pre-wrap; word-break: break-word; }
@@ -635,107 +824,107 @@ def _build_watch_ui_html() -> str:
   </style>
 </head>
 <body>
-  <div class=\"wrap\">
-    <div style=\"display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px;flex-wrap:wrap;\">
+  <div class="wrap">
+    <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:16px;margin-bottom:16px;flex-wrap:wrap;">
       <div>
         <h1>Companion Watch</h1>
-        <div class=\"muted\">Live file watch, Import.log auto-resolution, SSE stream, and recent event view.</div>
+        <div class="muted">Live file watch, Import.log auto-resolution, SSE stream, and recent event view.</div>
       </div>
       <div>
-        <span id=\"runningBadge\" class=\"badge\">stopped</span>
-        <span id=\"streamBadge\" class=\"badge\">stream idle</span>
+        <span id="runningBadge" class="badge">stopped</span>
+        <span id="streamBadge" class="badge">stream idle</span>
       </div>
     </div>
-    <div class=\"grid\">
-      <section class=\"panel\">
+    <div class="grid">
+      <section class="panel">
         <h2>Auto Import.log Watch</h2>
-        <div class=\"row\">
+        <div class="row">
           <div>
-            <label for=\"importLocation\">Location</label>
-            <select id=\"importLocation\">
-              <option value=\"server\">Server file</option>
-              <option value=\"local\">Local database file</option>
+            <label for="importLocation">Location</label>
+            <select id="importLocation">
+              <option value="server">Server file</option>
+              <option value="local">Local database file</option>
             </select>
           </div>
           <div>
-            <label for=\"importAnalyzer\">Analyzer</label>
-            <select id=\"importAnalyzer\">
-              <option value=\"import_log_unknown_attributes\">Unknown attributes only</option>
-              <option value=\"import_log\">All Import.log issues</option>
+            <label for="importAnalyzer">Analyzer</label>
+            <select id="importAnalyzer">
+              <option value="import_log">All Import.log issues</option>
+              <option value="import_log_unknown_attributes">Unknown attributes only</option>
             </select>
           </div>
         </div>
-        <div class=\"row single\">
+        <div class="row single">
           <div>
-            <label for=\"databasePath\">Database path or folder for local file mode</label>
-            <input id=\"databasePath\" placeholder=\"/path/to/MyFile.fmp12\">
+            <label for="databasePath">Database path or folder for local file mode</label>
+            <input id="databasePath" placeholder="/path/to/MyFile.fmp12">
           </div>
         </div>
-        <div class=\"row\">
+        <div class="row">
           <div>
-            <label for=\"documentsDir\">Documents dir for server mode</label>
-            <input id=\"documentsDir\" value=\"~/Documents\">
+            <label for="documentsDir">Documents dir for server mode</label>
+            <input id="documentsDir" value="~/Documents">
           </div>
           <div>
-            <label for=\"importPollInterval\">Poll interval</label>
-            <input id=\"importPollInterval\" value=\"0.5\">
+            <label for="importPollInterval">Poll interval</label>
+            <input id="importPollInterval" value="0.5">
           </div>
         </div>
-        <div class=\"button-row\">
-          <button id=\"startImportButton\">Start Import.log watch</button>
+        <div class="button-row">
+          <button id="startImportButton">Start Import.log watch</button>
         </div>
       </section>
-      <section class=\"panel\">
+      <section class="panel">
         <h2>Custom File Watch</h2>
-        <div class=\"row single\">
+        <div class="row single">
           <div>
-            <label for=\"customPath\">File path</label>
-            <input id=\"customPath\" placeholder=\"/path/to/file.log\">
+            <label for="customPath">File path</label>
+            <input id="customPath" placeholder="/path/to/file.log">
           </div>
         </div>
-        <div class=\"row\">
+        <div class="row">
           <div>
-            <label for=\"customAnalyzer\">Analyzer</label>
-            <select id=\"customAnalyzer\">
-              <option value=\"import_log_unknown_attributes\">Import.log unknown attributes</option>
-              <option value=\"import_log\">Import.log issues</option>
+            <label for="customAnalyzer">Analyzer</label>
+            <select id="customAnalyzer">
+              <option value="import_log">Import.log issues</option>
+              <option value="import_log_unknown_attributes">Import.log unknown attributes</option>
             </select>
           </div>
           <div>
-            <label for=\"customPollInterval\">Poll interval</label>
-            <input id=\"customPollInterval\" value=\"0.5\">
+            <label for="customPollInterval">Poll interval</label>
+            <input id="customPollInterval" value="0.5">
           </div>
         </div>
-        <div class=\"row single\">
+        <div class="row single">
           <div>
-            <label for=\"startAtEnd\">Start at end of file</label>
-            <select id=\"startAtEnd\">
-              <option value=\"true\">true</option>
-              <option value=\"false\">false</option>
+            <label for="startAtEnd">Start at end of file</label>
+            <select id="startAtEnd">
+              <option value="true">true</option>
+              <option value="false">false</option>
             </select>
           </div>
         </div>
-        <div class=\"button-row\">
-          <button id=\"startCustomButton\">Start custom watch</button>
-          <button id=\"stopButton\" class=\"danger\">Stop watch</button>
-          <button id=\"refreshButton\" class=\"secondary\">Refresh</button>
+        <div class="button-row">
+          <button id="startCustomButton">Start custom watch</button>
+          <button id="stopButton" class="danger">Stop watch</button>
+          <button id="refreshButton" class="secondary">Refresh</button>
         </div>
       </section>
-      <section class=\"panel full\">
+      <section class="panel full">
         <h2>Status</h2>
-        <div id=\"statusGrid\" class=\"kv\"></div>
+        <div id="statusGrid" class="kv"></div>
       </section>
-      <section class=\"panel\">
+      <section class="panel">
         <h2>Summary</h2>
-        <pre id=\"summaryView\">{}</pre>
+        <pre id="summaryView">{}</pre>
       </section>
-      <section class=\"panel\">
+      <section class="panel">
         <h2>Current / Last Import</h2>
-        <pre id=\"importView\">{}</pre>
+        <pre id="importView">{}</pre>
       </section>
-      <section class=\"panel full\">
+      <section class="panel full">
         <h2>Recent Events</h2>
-        <div id=\"events\" class=\"events\"></div>
+        <div id="events" class="events"></div>
       </section>
     </div>
   </div>
@@ -781,14 +970,21 @@ def _build_watch_ui_html() -> str:
       $('importView').textContent = JSON.stringify({
         current_import: state.summary?.current_import || {},
         last_completed_import: state.summary?.last_completed_import || {},
+        recent_imports: state.summary?.recent_imports || [],
       }, null, 2);
 
       const events = [...(state.recent_events || [])].reverse();
       $('events').innerHTML = events.length ? events.map((event) => {
         const bits = [
           event.detected_at || '',
+          event.severity || '',
           event.rule || '',
+          event.code ? `code ${event.code}` : '',
+          event.import_status || '',
+          event.imported_steps ? `steps ${event.imported_steps}` : '',
+          Number.isFinite(event.error_count) ? `errors ${event.error_count}` : '',
           event.script_name || '',
+          event.source || '',
           event.script_line || '',
           event.step_name || '',
           event.attribute_name || '',
@@ -1067,22 +1263,25 @@ class CompanionHandler(BaseHTTPRequestHandler):
             body = self._read_body()
             payload = json.loads(body) if body else {}
         except (ValueError, OSError) as exc:
-            self._send_json({"success": False, "error": f"Invalid request: {exc}"}, status=400)
+            self._send_json(
+                {"success": False, "exit_code": -1, "error": f"Invalid request: {exc}"},
+                status=400,
+            )
             return
 
         path = payload.get("path", "")
         if not path:
-            self._send_json({"success": False, "error": "Missing required field: path"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": "Missing required field: path"}, status=400)
             return
 
         try:
             poll_interval = float(payload.get("poll_interval", FILE_WATCH_POLL_INTERVAL_SECONDS))
         except (TypeError, ValueError):
-            self._send_json({"success": False, "error": "poll_interval must be a number"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be a number"}, status=400)
             return
 
         if poll_interval <= 0:
-            self._send_json({"success": False, "error": "poll_interval must be greater than 0"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be greater than 0"}, status=400)
             return
 
         start_at_end = bool(payload.get("start_at_end", True))
@@ -1091,11 +1290,11 @@ class CompanionHandler(BaseHTTPRequestHandler):
             analyzer_config = _normalize_analyzer_config(payload.get("analyzer"))
             state = _start_file_watch(path, poll_interval, start_at_end, analyzer_config)
         except ValueError as exc:
-            self._send_json({"success": False, "error": str(exc)}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=400)
             return
         except Exception as exc:
             log.exception("Failed to start file watch: %s", exc)
-            self._send_json({"success": False, "error": str(exc)}, status=500)
+            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=500)
             return
 
         log.info(
@@ -1112,31 +1311,31 @@ class CompanionHandler(BaseHTTPRequestHandler):
             body = self._read_body()
             payload = json.loads(body) if body else {}
         except (ValueError, OSError) as exc:
-            self._send_json({"success": False, "error": f"Invalid request: {exc}"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": f"Invalid request: {exc}"}, status=400)
             return
 
         try:
             poll_interval = float(payload.get("poll_interval", FILE_WATCH_POLL_INTERVAL_SECONDS))
         except (TypeError, ValueError):
-            self._send_json({"success": False, "error": "poll_interval must be a number"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be a number"}, status=400)
             return
 
         if poll_interval <= 0:
-            self._send_json({"success": False, "error": "poll_interval must be greater than 0"}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": "poll_interval must be greater than 0"}, status=400)
             return
 
         start_at_end = bool(payload.get("start_at_end", True))
 
         try:
             resolved = _resolve_import_log_path(payload)
-            analyzer_config = _normalize_analyzer_config(payload.get("analyzer", "import_log_unknown_attributes"))
+            analyzer_config = _normalize_analyzer_config(payload.get("analyzer", "import_log"))
             state = _start_file_watch(resolved["path"], poll_interval, start_at_end, analyzer_config)
         except ValueError as exc:
-            self._send_json({"success": False, "error": str(exc)}, status=400)
+            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=400)
             return
         except Exception as exc:
             log.exception("Failed to start Import.log watch: %s", exc)
-            self._send_json({"success": False, "error": str(exc)}, status=500)
+            self._send_json({"success": False, "exit_code": -1, "error": str(exc)}, status=500)
             return
 
         log.info(

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -730,6 +730,9 @@ def _process_import_log_line(line: str, analyzer_type: str) -> list[dict]:
                         if completed_import
                         else "Import completed."
                     ),
+                    source=completed_import.get("source", source),
+                    database_name=completed_import.get("database_name", source),
+                    script_name=completed_import.get("script_name", ""),
                     import_status=completed_import.get("status", "unknown"),
                     imported_steps=completed_import.get("imported_steps"),
                     error_count=int(completed_import.get("error_count", 0)),

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -357,7 +357,7 @@
             </div>
           </div>
           <div class="button-row">
-            <button type="button" id="startImportButton">Start Import.log watch</button>
+            <button type="button" id="startImportButton">Start watch</button>
             <button type="button" id="stopButton" class="danger">Stop watch</button>
             <button type="button" id="refreshButton" class="secondary">Refresh</button>
           </div>
@@ -457,19 +457,84 @@
         return source && source !== displayScriptName(importItem) ? source : "";
       }
 
+      function normalizeTimestamp(value) {
+        const raw = String(value ?? "").trim();
+        if (!raw) {
+          return null;
+        }
+        if (raw.includes("T")) {
+          const parsed = new Date(raw);
+          return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+        const match = raw.match(
+          /^(\d{4}-\d{2}-\d{2}) (\d{2}:\d{2}:\d{2})(?:\.(\d+))? ([+-]\d{2})(\d{2})$/,
+        );
+        if (match) {
+          const [, datePart, timePart, fraction = "", tzHour, tzMinute] = match;
+          const isoLike = `${datePart}T${timePart}${fraction ? `.${fraction}` : ""}${tzHour}:${tzMinute}`;
+          const parsed = new Date(isoLike);
+          return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+        return null;
+      }
+
+      function formatTimestamp(value) {
+        const raw = String(value ?? "").trim();
+        if (!raw) {
+          return "";
+        }
+        const parsed = normalizeTimestamp(raw);
+        if (!parsed) {
+          return raw;
+        }
+        return new Intl.DateTimeFormat(undefined, {
+          dateStyle: "medium",
+          timeStyle: "short",
+        }).format(parsed);
+      }
+
+      function formatStatusLastError(state) {
+        const summaryError = state.summary?.last_error;
+        if (summaryError && typeof summaryError === "object") {
+          const timestampText = formatTimestamp(
+            summaryError.timestamp || summaryError.detected_at || "",
+          );
+          const bits = [
+            timestampText,
+            summaryError.script_name || "",
+            summaryError.script_line ? `line ${summaryError.script_line}` : "",
+            summaryError.label || "",
+            summaryError.code ? `code ${summaryError.code}` : "",
+          ].filter(Boolean);
+          const prefix = bits.join(" · ");
+          const message = String(summaryError.message || "").trim();
+          if (prefix && message) {
+            return `${prefix}: ${message}`;
+          }
+          if (message) {
+            return message;
+          }
+        }
+        if (typeof state.last_error === "string") {
+          return state.last_error.trim();
+        }
+        return "";
+      }
+
       function renderStatus(state) {
         const running = Boolean(state.running);
         $("runningBadge").textContent = running ? "running" : "stopped";
         $("runningBadge").className = `badge ${running ? "ok" : "warn"}`;
+        const lastErrorText = formatStatusLastError(state);
         $("statusGrid").innerHTML = [
           ["Path", state.path || ""],
           ["File exists", String(Boolean(state.file_exists))],
           ["Analyzer", state.analyzer?.type || ""],
           ["Poll interval", String(state.poll_interval ?? "")],
-          ["Started at", state.started_at || ""],
-          ["Last change", state.last_change_at || ""],
-          ["Last event", state.last_event_at || ""],
-          ["Last error", state.last_error || ""],
+          ["Started at", formatTimestamp(state.started_at)],
+          ["Last change", formatTimestamp(state.last_change_at)],
+          ["Last event", formatTimestamp(state.last_event_at)],
+          ["Last error", lastErrorText],
           ["Revision", String(state.revision ?? "")],
         ]
           .map(
@@ -542,8 +607,8 @@
         const source = displayImportSource(importItem);
         const subtitleBits = [
           source,
-          importItem.started_at ? `started ${importItem.started_at}` : "",
-          importItem.completed_at ? `completed ${importItem.completed_at}` : "",
+          importItem.started_at ? `started ${formatTimestamp(importItem.started_at)}` : "",
+          importItem.completed_at ? `completed ${formatTimestamp(importItem.completed_at)}` : "",
         ]
           .filter(Boolean)
           .join(" · ");
@@ -556,7 +621,7 @@
             <div class="import-head-left">
               <div class="import-title">
                 <h3>${escapeHtml(displayScriptName(importItem))}</h3>
-                <span class="badge ${statusClass === "warn" ? "warn" : statusClass === "running" ? "info" : "ok"}">${escapeHtml(statusText)}</span>
+                <span class="badge ${statusClass}">${escapeHtml(statusText)}</span>
                 ${isCurrent ? '<span class="badge info">current</span>' : ""}
               </div>
               <div class="import-subtitle">${escapeHtml(subtitleBits || "No source metadata")}</div>

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -591,12 +591,17 @@
         return "";
       }
 
-      function getIssueEvents(state) {
+      function getCompletedImportErrorEvents(state) {
         if (!Array.isArray(state.recent_events)) {
           return [];
         }
         return state.recent_events.filter(
-          (event) => event && event.event_type === "import_log_issue",
+          (event) =>
+            event &&
+            event.event_type === "import_log_lifecycle" &&
+            event.rule === "import_completed" &&
+            event.import_status === "with_errors" &&
+            Number(event.error_count || 0) > 0,
         );
       }
 
@@ -615,16 +620,31 @@
         ].join("||");
       }
 
-      function buildNotificationBody(error) {
-        const meta = [
-          formatTimestamp(error.timestamp || error.detected_at || ""),
-          error.script_line ? `line ${error.script_line}` : "",
-          error.label || "",
-          error.code ? `code ${error.code}` : "",
-        ]
-          .filter(Boolean)
-          .join(" · ");
-        return [meta, String(error.message || "").trim()].filter(Boolean).join("\n");
+      function buildNotificationSolutionName(event) {
+        const rawSource = String(event.source || event.database_name || "").trim();
+        if (!rawSource) {
+          return "Unknown solution";
+        }
+        const pathBits = rawSource.split(/[/\\]/);
+        const lastBit = pathBits[pathBits.length - 1] || rawSource;
+        return lastBit || "Unknown solution";
+      }
+
+      function buildNotificationHeadline(event) {
+        const solutionName = buildNotificationSolutionName(event);
+        const scriptName = String(event.script_name || "").trim();
+        if (scriptName) {
+          return `${scriptName} (${solutionName})`;
+        }
+        return solutionName;
+      }
+
+      function buildNotificationBody(event) {
+        const headline = buildNotificationHeadline(event);
+        const timestampText = formatTimestamp(event.timestamp || event.detected_at || "");
+        const errorCount = Number(event.error_count || 0);
+        const errorText = `${errorCount} error${errorCount === 1 ? "" : "s"}`;
+        return [headline, timestampText, errorText].join("\n");
       }
 
       function deliverNotification(title, body, tag) {
@@ -645,14 +665,15 @@
         return notification;
       }
 
-      function showImportErrorNotification(error) {
+      function showImportErrorNotification(event) {
         if (!notificationsSupported() || Notification.permission !== "granted") {
           return;
         }
-        const title = error.script_name
-          ? `Import error in ${error.script_name}`
-          : "Import error detected";
-        deliverNotification(title, buildNotificationBody(error), buildNotificationKey(error));
+        deliverNotification(
+          "Import completed with errors",
+          buildNotificationBody(event),
+          buildNotificationKey(event),
+        );
       }
 
       function showNotificationsEnabledPreview() {
@@ -668,8 +689,8 @@
 
       function syncErrorNotifications(state) {
         updateNotificationsButton();
-        const issueEvents = getIssueEvents(state);
-        const currentKeys = issueEvents
+        const completedErrorEvents = getCompletedImportErrorEvents(state);
+        const currentKeys = completedErrorEvents
           .map((event) => buildNotificationKey(event))
           .filter(Boolean);
         if (!notificationsPrimed) {
@@ -677,7 +698,7 @@
           notificationsPrimed = true;
           return;
         }
-        const newEvents = issueEvents.filter((event) => {
+        const newEvents = completedErrorEvents.filter((event) => {
           const key = buildNotificationKey(event);
           return key && !seenNotificationKeys.has(key);
         });

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -68,6 +68,32 @@
       .compact-field {
         max-width: 160px;
       }
+      .header-actions {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+      }
+      .header-button {
+        width: auto;
+        padding: 6px 10px;
+        border-radius: 999px;
+        font-size: 12px;
+        line-height: 1.1;
+        white-space: nowrap;
+      }
+      .header-button.on {
+        background: linear-gradient(180deg, #1f8f58, #187447);
+      }
+      .header-button.off {
+        background: #1a2342;
+        border: 1px solid #334269;
+      }
+      .header-button:disabled {
+        opacity: 0.72;
+        cursor: default;
+      }
       .input-with-actions {
         display: flex;
         gap: 10px;
@@ -310,7 +336,8 @@
             clear error details.
           </div>
         </div>
-        <div style="display: flex; gap: 8px; flex-wrap: wrap">
+        <div class="header-actions">
+          <button type="button" id="notificationsButton" class="header-button off">Enable notifications</button>
           <span id="runningBadge" class="badge">stopped</span>
           <span id="streamBadge" class="badge">stream idle</span>
         </div>
@@ -380,6 +407,53 @@
       const $ = (id) => document.getElementById(id);
       let stream = null;
       let defaultsApplied = false;
+      let notificationsEnabled = loadNotificationsPreference();
+      let notificationsPrimed = false;
+      let seenNotificationKeys = new Set();
+
+      function loadNotificationsPreference() {
+        try {
+          return window.localStorage.getItem("agenticFmWatchNotificationsEnabled") === "true";
+        } catch {
+          return false;
+        }
+      }
+
+      function saveNotificationsPreference(value) {
+        try {
+          window.localStorage.setItem("agenticFmWatchNotificationsEnabled", value ? "true" : "false");
+        } catch {}
+      }
+
+      function notificationsSupported() {
+        return typeof window.Notification !== "undefined";
+      }
+
+      function updateNotificationsButton() {
+        const button = $("notificationsButton");
+        if (!button) {
+          return;
+        }
+        if (!notificationsSupported()) {
+          button.textContent = "Notifications unavailable";
+          button.className = "header-button off";
+          button.disabled = true;
+          return;
+        }
+        button.disabled = false;
+        if (Notification.permission === "denied") {
+          button.textContent = "Notifications blocked";
+          button.className = "header-button off";
+          return;
+        }
+        if (Notification.permission === "granted" && notificationsEnabled) {
+          button.textContent = "Notifications on";
+          button.className = "header-button on";
+          return;
+        }
+        button.textContent = "Enable notifications";
+        button.className = "header-button off";
+      }
 
       function setStreamBadge(text, level = "") {
         $("streamBadge").textContent = text;
@@ -515,6 +589,135 @@
           return state.last_error.trim();
         }
         return "";
+      }
+
+      function getIssueEvents(state) {
+        if (!Array.isArray(state.recent_events)) {
+          return [];
+        }
+        return state.recent_events.filter(
+          (event) => event && event.event_type === "import_log_issue",
+        );
+      }
+
+      function buildNotificationKey(event) {
+        if (!event) {
+          return "";
+        }
+        return [
+          event.detected_at || event.timestamp || "",
+          event.rule || "",
+          event.code || "",
+          event.source || "",
+          event.script_name || "",
+          event.script_line || "",
+          event.message || "",
+        ].join("||");
+      }
+
+      function buildNotificationBody(error) {
+        const meta = [
+          formatTimestamp(error.timestamp || error.detected_at || ""),
+          error.script_line ? `line ${error.script_line}` : "",
+          error.label || "",
+          error.code ? `code ${error.code}` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        return [meta, String(error.message || "").trim()].filter(Boolean).join("\n");
+      }
+
+      function deliverNotification(title, body, tag) {
+        if (!notificationsSupported()) {
+          throw new Error("This browser does not support system notifications.");
+        }
+        if (Notification.permission !== "granted") {
+          throw new Error("Notification permission has not been granted.");
+        }
+        const notification = new Notification(title, {
+          body,
+          tag: tag || undefined,
+        });
+        notification.onclick = () => {
+          window.focus();
+          notification.close();
+        };
+        return notification;
+      }
+
+      function showImportErrorNotification(error) {
+        if (!notificationsSupported() || Notification.permission !== "granted") {
+          return;
+        }
+        const title = error.script_name
+          ? `Import error in ${error.script_name}`
+          : "Import error detected";
+        deliverNotification(title, buildNotificationBody(error), buildNotificationKey(error));
+      }
+
+      function showNotificationsEnabledPreview() {
+        if (!notificationsSupported() || Notification.permission !== "granted") {
+          return;
+        }
+        deliverNotification(
+          "Import notifications enabled",
+          "You will now receive alerts here for new import errors while this page stays open.",
+          "agentic-fm-watch-notifications-enabled",
+        );
+      }
+
+      function syncErrorNotifications(state) {
+        updateNotificationsButton();
+        const issueEvents = getIssueEvents(state);
+        const currentKeys = issueEvents
+          .map((event) => buildNotificationKey(event))
+          .filter(Boolean);
+        if (!notificationsPrimed) {
+          seenNotificationKeys = new Set(currentKeys);
+          notificationsPrimed = true;
+          return;
+        }
+        const newEvents = issueEvents.filter((event) => {
+          const key = buildNotificationKey(event);
+          return key && !seenNotificationKeys.has(key);
+        });
+        seenNotificationKeys = new Set(currentKeys);
+        if (!newEvents.length) {
+          return;
+        }
+        if (!notificationsEnabled || !notificationsSupported() || Notification.permission !== "granted") {
+          return;
+        }
+        const latestEvent = newEvents[newEvents.length - 1];
+        showImportErrorNotification(latestEvent);
+      }
+
+      async function toggleNotifications() {
+        if (!notificationsSupported()) {
+          alert("This browser does not support system notifications.");
+          return;
+        }
+        if (Notification.permission === "denied") {
+          alert("Notifications are blocked for this page. Enable them in your browser settings.");
+          updateNotificationsButton();
+          return;
+        }
+        if (Notification.permission === "granted") {
+          notificationsEnabled = !notificationsEnabled;
+          saveNotificationsPreference(notificationsEnabled);
+          updateNotificationsButton();
+          if (notificationsEnabled) {
+            showNotificationsEnabledPreview();
+          }
+          return;
+        }
+        const permission = await Notification.requestPermission();
+        notificationsEnabled = permission === "granted";
+        saveNotificationsPreference(notificationsEnabled);
+        updateNotificationsButton();
+        if (notificationsEnabled) {
+          showNotificationsEnabledPreview();
+        }
       }
 
       function renderStatus(state) {
@@ -656,6 +859,7 @@
         renderStatus(state);
         renderStats(state.summary || {});
         renderImports(state.summary || {});
+        syncErrorNotifications(state);
       }
 
       async function refresh() {
@@ -749,7 +953,11 @@
       $("browseDocumentsDirButton").addEventListener("click", () =>
         browseDocumentsDir().catch((error) => alert(error.message)),
       );
+      $("notificationsButton").addEventListener("click", () =>
+        toggleNotifications().catch((error) => alert(error.message)),
+      );
 
+      updateNotificationsButton();
       refresh().then((state) => {
         if (state?.running) {
           connectStream();

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -138,6 +138,10 @@
       button.danger {
         background: linear-gradient(180deg, #c9405e, #a52d48);
       }
+      button:disabled {
+        cursor: default;
+        opacity: 0.5;
+      }
       .button-row {
         display: flex;
         gap: 10px;
@@ -382,7 +386,6 @@
           <div class="button-row">
             <button type="button" id="startImportButton">Start watch</button>
             <button type="button" id="stopButton" class="danger">Stop watch</button>
-            <button type="button" id="refreshButton" class="secondary">Refresh</button>
           </div>
         </section>
 
@@ -458,6 +461,21 @@
       function setStreamBadge(text, level = "") {
         $("streamBadge").textContent = text;
         $("streamBadge").className = `badge${level ? ` ${level}` : ""}`;
+      }
+
+      function updateWatchActionButtons(running) {
+        const startButton = $("startImportButton");
+        const stopButton = $("stopButton");
+        if (startButton) {
+          startButton.hidden = Boolean(running);
+          startButton.disabled = Boolean(running);
+          startButton.className = "";
+        }
+        if (stopButton) {
+          stopButton.hidden = !running;
+          stopButton.disabled = !running;
+          stopButton.className = "danger";
+        }
       }
 
       function escapeHtml(value) {
@@ -745,6 +763,7 @@
         const running = Boolean(state.running);
         $("runningBadge").textContent = running ? "running" : "stopped";
         $("runningBadge").className = `badge ${running ? "ok" : "warn"}`;
+        updateWatchActionButtons(running);
         const lastErrorText = formatStatusLastError(state);
         $("statusGrid").innerHTML = [
           ["Path", state.path || ""],
@@ -965,9 +984,6 @@
       $("stopButton").addEventListener("click", () =>
         stopWatch().catch((error) => alert(error.message)),
       );
-      $("refreshButton").addEventListener("click", () =>
-        refresh().catch((error) => alert(error.message)),
-      );
       $("browseDatabaseFolderButton").addEventListener("click", () =>
         browseDatabaseFolder().catch((error) => alert(error.message)),
       );
@@ -978,6 +994,7 @@
         toggleNotifications().catch((error) => alert(error.message)),
       );
 
+      updateWatchActionButtons(false);
       updateNotificationsButton();
       refresh().then((state) => {
         if (state?.running) {

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -62,6 +62,12 @@
       .row.single {
         grid-template-columns: 1fr;
       }
+      .row.compact-poll {
+        grid-template-columns: minmax(0, 1.8fr) minmax(110px, 160px);
+      }
+      .compact-field {
+        max-width: 160px;
+      }
       .input-with-actions {
         display: flex;
         gap: 10px;
@@ -343,7 +349,7 @@
               </div>
             </div>
           </div>
-          <div class="row">
+          <div class="row compact-poll">
             <div>
               <label for="documentsDir">Documents dir for server mode</label>
               <div class="input-with-actions">
@@ -351,7 +357,7 @@
                 <button type="button" id="browseDocumentsDirButton" class="secondary">Browse…</button>
               </div>
             </div>
-            <div>
+            <div class="compact-field">
               <label for="importPollInterval">Poll interval</label>
               <input id="importPollInterval" value="0.5" />
             </div>

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -62,7 +62,7 @@
       .row.single {
         grid-template-columns: 1fr;
       }
-      .row.compact-poll {
+      .row.top-controls {
         grid-template-columns: minmax(0, 1.8fr) minmax(110px, 160px);
       }
       .compact-field {
@@ -306,8 +306,8 @@
         <div>
           <h1>Companion Watch</h1>
           <div class="muted">
-            Import sessions with script headers, imported line counts, and
-            compact line-first error rows.
+            Track each import with its script name, imported line count, and
+            clear error details.
           </div>
         </div>
         <div style="display: flex; gap: 8px; flex-wrap: wrap">
@@ -319,7 +319,7 @@
       <div class="grid">
         <section class="panel">
           <h2>Auto Import.log Watch</h2>
-          <div class="row">
+          <div class="row top-controls">
             <div>
               <label for="importLocation">Location</label>
               <select id="importLocation">
@@ -327,14 +327,9 @@
                 <option value="local">Local database file</option>
               </select>
             </div>
-            <div>
-              <label for="importAnalyzer">Analyzer</label>
-              <select id="importAnalyzer">
-                <option value="import_log">All Import.log issues</option>
-                <option value="import_log_unknown_attributes">
-                  Unknown attributes only
-                </option>
-              </select>
+            <div class="compact-field">
+              <label for="importPollInterval">Poll interval</label>
+              <input id="importPollInterval" value="0.5" />
             </div>
           </div>
           <div class="row single">
@@ -349,17 +344,13 @@
               </div>
             </div>
           </div>
-          <div class="row compact-poll">
+          <div class="row single">
             <div>
               <label for="documentsDir">Documents dir for server mode</label>
               <div class="input-with-actions">
                 <input id="documentsDir" placeholder="Documents folder" />
                 <button type="button" id="browseDocumentsDirButton" class="secondary">Browse…</button>
               </div>
-            </div>
-            <div class="compact-field">
-              <label for="importPollInterval">Poll interval</label>
-              <input id="importPollInterval" value="0.5" />
             </div>
           </div>
           <div class="button-row">
@@ -706,7 +697,7 @@
           database_path: $("databasePath").value.trim(),
           documents_dir: $("documentsDir").value.trim(),
           poll_interval: Number($("importPollInterval").value || "0.5"),
-          analyzer: $("importAnalyzer").value,
+          analyzer: "import_log",
           start_at_end: true,
         };
         await request("/watch/import-log/start", "POST", payload);

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -1,0 +1,657 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>agentic-fm: Script Import Companion</title>
+    <style>
+      :root {
+        color-scheme: dark;
+      }
+      body {
+        margin: 0;
+        font-family: Inter, system-ui, sans-serif;
+        background: #0b1020;
+        color: #e5e7eb;
+      }
+      .wrap {
+        max-width: 1220px;
+        margin: 0 auto;
+        padding: 24px;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 16px;
+      }
+      .panel {
+        background: #121933;
+        border: 1px solid #26304f;
+        border-radius: 14px;
+        padding: 16px;
+        box-shadow: 0 10px 30px rgba(0, 0, 0, 0.18);
+      }
+      .panel.full {
+        grid-column: 1 / -1;
+      }
+      h1,
+      h2,
+      h3 {
+        margin: 0;
+      }
+      h1 {
+        font-size: 24px;
+        margin-bottom: 10px;
+      }
+      h2 {
+        font-size: 16px;
+        margin-bottom: 12px;
+      }
+      h3 {
+        font-size: 17px;
+      }
+      .muted {
+        color: #93a1c6;
+      }
+      .row {
+        display: grid;
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        gap: 12px;
+        margin-bottom: 12px;
+      }
+      .row.single {
+        grid-template-columns: 1fr;
+      }
+      label {
+        display: block;
+        font-size: 12px;
+        color: #93a1c6;
+        margin-bottom: 6px;
+      }
+      input,
+      select,
+      button {
+        width: 100%;
+        box-sizing: border-box;
+        border-radius: 10px;
+        border: 1px solid #334269;
+        background: #0f1530;
+        color: #eef2ff;
+        padding: 10px 12px;
+        font: inherit;
+      }
+      button {
+        cursor: pointer;
+        background: linear-gradient(180deg, #4169e1, #3558c8);
+        border: none;
+        font-weight: 600;
+      }
+      button.secondary {
+        background: #1a2342;
+        border: 1px solid #334269;
+      }
+      button.danger {
+        background: linear-gradient(180deg, #c9405e, #a52d48);
+      }
+      .button-row {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .button-row > * {
+        flex: 1 1 180px;
+      }
+      .badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        padding: 6px 10px;
+        border-radius: 999px;
+        background: #1a2342;
+        color: #c7d2fe;
+        font-size: 12px;
+      }
+      .badge.ok {
+        background: #16351e;
+        color: #9ae6b4;
+      }
+      .badge.warn {
+        background: #3a2712;
+        color: #fbd38d;
+      }
+      .badge.err {
+        background: #3d1620;
+        color: #feb2b2;
+      }
+      .badge.info {
+        background: #162b4d;
+        color: #93c5fd;
+      }
+      .status-grid {
+        display: grid;
+        grid-template-columns: 180px 1fr;
+        gap: 8px;
+        font-size: 13px;
+      }
+      .stats {
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .stat {
+        min-width: 140px;
+        background: #0d1430;
+        border: 1px solid #2e395d;
+        border-radius: 12px;
+        padding: 12px;
+      }
+      .stat .label {
+        color: #93a1c6;
+        font-size: 12px;
+      }
+      .stat .value {
+        font-size: 24px;
+        font-weight: 700;
+        margin-top: 4px;
+      }
+      .imports {
+        display: grid;
+        gap: 14px;
+      }
+      .import-card {
+        background: #0d1430;
+        border: 1px solid #2e395d;
+        border-radius: 14px;
+        overflow: hidden;
+      }
+      .import-card.ok {
+        border-color: #215032;
+      }
+      .import-card.warn {
+        border-color: #7a5a26;
+      }
+      .import-card.running {
+        border-color: #2f5d8a;
+      }
+      .import-head {
+        display: flex;
+        justify-content: space-between;
+        gap: 12px;
+        align-items: flex-start;
+        padding: 14px 16px;
+        border-bottom: 1px solid #223053;
+      }
+      .import-head-left {
+        min-width: 0;
+      }
+      .import-title {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+        flex-wrap: wrap;
+      }
+      .import-subtitle {
+        margin-top: 6px;
+        color: #93a1c6;
+        font-size: 13px;
+      }
+      .import-head-right {
+        display: flex;
+        gap: 8px;
+        flex-wrap: wrap;
+        justify-content: flex-end;
+      }
+      .import-body {
+        padding: 10px 0;
+      }
+      .error-list {
+        display: grid;
+      }
+      .error-row {
+        display: grid;
+        grid-template-columns: 110px 1fr;
+        gap: 12px;
+        padding: 10px 16px;
+        border-top: 1px solid #1b2748;
+      }
+      .error-row:first-child {
+        border-top: none;
+      }
+      .line-pill {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        min-height: 34px;
+        border-radius: 999px;
+        background: #182344;
+        color: #e0e7ff;
+        font-weight: 700;
+        padding: 0 12px;
+      }
+      .line-pill.empty {
+        background: #20283c;
+        color: #a5b4d4;
+      }
+      .error-meta {
+        color: #b9c4e3;
+        font-size: 13px;
+        margin-bottom: 4px;
+      }
+      .error-message {
+        white-space: pre-wrap;
+        word-break: break-word;
+        font-size: 14px;
+      }
+      .empty-state {
+        padding: 14px 16px;
+        color: #93a1c6;
+      }
+      .hidden {
+        display: none;
+      }
+      @media (max-width: 900px) {
+        .grid,
+        .row {
+          grid-template-columns: 1fr;
+        }
+        .status-grid {
+          grid-template-columns: 1fr;
+        }
+        .import-head {
+          flex-direction: column;
+        }
+        .import-head-right {
+          justify-content: flex-start;
+        }
+        .error-row {
+          grid-template-columns: 1fr;
+        }
+        .line-pill {
+          justify-content: flex-start;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div
+        style="
+          display: flex;
+          justify-content: space-between;
+          align-items: flex-start;
+          gap: 16px;
+          margin-bottom: 16px;
+          flex-wrap: wrap;
+        "
+      >
+        <div>
+          <h1>Companion Watch</h1>
+          <div class="muted">
+            Import sessions with script headers, imported line counts, and
+            compact line-first error rows.
+          </div>
+        </div>
+        <div style="display: flex; gap: 8px; flex-wrap: wrap">
+          <span id="runningBadge" class="badge">stopped</span>
+          <span id="streamBadge" class="badge">stream idle</span>
+        </div>
+      </div>
+
+      <div class="grid">
+        <section class="panel">
+          <h2>Auto Import.log Watch</h2>
+          <div class="row">
+            <div>
+              <label for="importLocation">Location</label>
+              <select id="importLocation">
+                <option value="server">Server file</option>
+                <option value="local">Local database file</option>
+              </select>
+            </div>
+            <div>
+              <label for="importAnalyzer">Analyzer</label>
+              <select id="importAnalyzer">
+                <option value="import_log">All Import.log issues</option>
+                <option value="import_log_unknown_attributes">
+                  Unknown attributes only
+                </option>
+              </select>
+            </div>
+          </div>
+          <div class="row single">
+            <div>
+              <label for="databasePath"
+                >Database path or folder for local file mode</label
+              >
+              <input id="databasePath" placeholder="/path/to/MyFile.fmp12" />
+            </div>
+          </div>
+          <div class="row">
+            <div>
+              <label for="documentsDir">Documents dir for server mode</label>
+              <input id="documentsDir" value="~/Documents" />
+            </div>
+            <div>
+              <label for="importPollInterval">Poll interval</label>
+              <input id="importPollInterval" value="0.5" />
+            </div>
+          </div>
+          <div class="button-row">
+            <button id="startImportButton">Start Import.log watch</button>
+          </div>
+        </section>
+
+        <section class="panel">
+          <h2>Custom File Watch</h2>
+          <div class="row single">
+            <div>
+              <label for="customPath">File path</label>
+              <input id="customPath" placeholder="/path/to/file.log" />
+            </div>
+          </div>
+          <div class="row">
+            <div>
+              <label for="customAnalyzer">Analyzer</label>
+              <select id="customAnalyzer">
+                <option value="import_log">Import.log issues</option>
+                <option value="import_log_unknown_attributes">
+                  Import.log unknown attributes
+                </option>
+              </select>
+            </div>
+            <div>
+              <label for="customPollInterval">Poll interval</label>
+              <input id="customPollInterval" value="0.5" />
+            </div>
+          </div>
+          <div class="row single">
+            <div>
+              <label for="startAtEnd">Start at end of file</label>
+              <select id="startAtEnd">
+                <option value="true">true</option>
+                <option value="false">false</option>
+              </select>
+            </div>
+          </div>
+          <div class="button-row">
+            <button id="startCustomButton">Start custom watch</button>
+            <button id="stopButton" class="danger">Stop watch</button>
+            <button id="refreshButton" class="secondary">Refresh</button>
+          </div>
+        </section>
+
+        <section class="panel full">
+          <h2>Status</h2>
+          <div id="statusGrid" class="status-grid"></div>
+        </section>
+
+        <section class="panel full">
+          <h2>Import Summary</h2>
+          <div id="stats" class="stats"></div>
+        </section>
+
+        <section class="panel full">
+          <h2>Recent Imports</h2>
+          <div id="imports" class="imports"></div>
+        </section>
+      </div>
+    </div>
+
+    <script>
+      const $ = (id) => document.getElementById(id);
+      let stream = null;
+
+      function escapeHtml(value) {
+        return String(value ?? "")
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;");
+      }
+
+      async function request(path, method = "GET", body = null) {
+        const response = await fetch(path, {
+          method,
+          headers: body ? { "Content-Type": "application/json" } : {},
+          body: body ? JSON.stringify(body) : null,
+        });
+        const text = await response.text();
+        const data = text ? JSON.parse(text) : {};
+        if (!response.ok) {
+          throw new Error(data.error || `HTTP ${response.status}`);
+        }
+        return data;
+      }
+
+      function displayScriptName(importItem) {
+        return (
+          importItem.script_name ||
+          importItem.source ||
+          importItem.database_name ||
+          "Unknown script"
+        );
+      }
+
+      function displayImportSource(importItem) {
+        const source = importItem.database_name || importItem.source || "";
+        return source && source !== displayScriptName(importItem) ? source : "";
+      }
+
+      function renderStatus(state) {
+        const running = Boolean(state.running);
+        $("runningBadge").textContent = running ? "running" : "stopped";
+        $("runningBadge").className = `badge ${running ? "ok" : "warn"}`;
+        $("statusGrid").innerHTML = [
+          ["Path", state.path || ""],
+          ["File exists", String(Boolean(state.file_exists))],
+          ["Analyzer", state.analyzer?.type || ""],
+          ["Poll interval", String(state.poll_interval ?? "")],
+          ["Started at", state.started_at || ""],
+          ["Last change", state.last_change_at || ""],
+          ["Last event", state.last_event_at || ""],
+          ["Last error", state.last_error || ""],
+          ["Revision", String(state.revision ?? "")],
+        ]
+          .map(
+            ([key, value]) =>
+              `<div class="muted">${escapeHtml(key)}</div><div>${escapeHtml(value)}</div>`,
+          )
+          .join("");
+      }
+
+      function renderStats(summary = {}) {
+        const stats = [
+          ["Imports", summary.imports_total ?? 0],
+          ["No errors", summary.imports_without_errors ?? 0],
+          ["With errors", summary.imports_with_errors ?? 0],
+          ["Total errors", summary.errors_total ?? 0],
+          ["Total events", summary.events_total ?? 0],
+        ];
+        $("stats").innerHTML = stats
+          .map(
+            ([label, value]) => `
+        <div class="stat">
+          <div class="label">${escapeHtml(label)}</div>
+          <div class="value">${escapeHtml(value)}</div>
+        </div>
+      `,
+          )
+          .join("");
+      }
+
+      function renderErrorRow(error) {
+        const lineText = error.line_number
+          ? `Line ${error.line_number}`
+          : "No line";
+        const meta = [
+          error.step_name || "",
+          error.label || "",
+          error.code ? `code ${error.code}` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        return `
+        <div class="error-row">
+          <div><span class="line-pill${error.line_number ? "" : " empty"}">${escapeHtml(lineText)}</span></div>
+          <div>
+            <div class="error-meta">${escapeHtml(meta)}</div>
+            <div class="error-message">${escapeHtml(error.message || "")}</div>
+          </div>
+        </div>
+      `;
+      }
+
+      function renderImportCard(importItem, isCurrent = false) {
+        const errors = Array.isArray(importItem.errors)
+          ? importItem.errors
+          : [];
+        const status = importItem.status || (isCurrent ? "running" : "ok");
+        const statusClass =
+          status === "with_errors"
+            ? "warn"
+            : status === "running"
+              ? "running"
+              : "ok";
+        const statusText =
+          status === "with_errors"
+            ? "with errors"
+            : status === "running"
+              ? "running"
+              : "ok";
+        const importedSteps = importItem.imported_steps ?? "—";
+        const source = displayImportSource(importItem);
+        const subtitleBits = [
+          source,
+          importItem.started_at ? `started ${importItem.started_at}` : "",
+          importItem.completed_at ? `completed ${importItem.completed_at}` : "",
+        ]
+          .filter(Boolean)
+          .join(" · ");
+        const body = errors.length
+          ? `<div class="error-list">${errors.map(renderErrorRow).join("")}</div>`
+          : `<div class="empty-state">${status === "running" ? "Import running. No errors recorded yet." : "No errors occurred during this import."}</div>`;
+        return `
+        <article class="import-card ${escapeHtml(statusClass)}">
+          <div class="import-head">
+            <div class="import-head-left">
+              <div class="import-title">
+                <h3>${escapeHtml(displayScriptName(importItem))}</h3>
+                <span class="badge ${statusClass === "warn" ? "warn" : statusClass === "running" ? "info" : "ok"}">${escapeHtml(statusText)}</span>
+                ${isCurrent ? '<span class="badge info">current</span>' : ""}
+              </div>
+              <div class="import-subtitle">${escapeHtml(subtitleBits || "No source metadata")}</div>
+            </div>
+            <div class="import-head-right">
+              <span class="badge info">lines imported ${escapeHtml(importedSteps)}</span>
+              <span class="badge ${errors.length ? "err" : "ok"}">errors ${escapeHtml(importItem.error_count ?? errors.length)}</span>
+            </div>
+          </div>
+          <div class="import-body">${body}</div>
+        </article>
+      `;
+      }
+
+      function renderImports(summary = {}) {
+        const imports = [];
+        const currentImport = summary.current_import || {};
+        if (
+          currentImport &&
+          (currentImport.started_at ||
+            currentImport.script_name ||
+            currentImport.source)
+        ) {
+          imports.push(renderImportCard(currentImport, true));
+        }
+        const recentImports = [...(summary.recent_imports || [])].reverse();
+        for (const importItem of recentImports) {
+          imports.push(renderImportCard(importItem, false));
+        }
+        $("imports").innerHTML = imports.length
+          ? imports.join("")
+          : '<div class="empty-state">No imports recorded yet.</div>';
+      }
+
+      function render(state) {
+        renderStatus(state);
+        renderStats(state.summary || {});
+        renderImports(state.summary || {});
+      }
+
+      async function refresh() {
+        try {
+          const state = await request("/watch/results");
+          render(state);
+        } catch (error) {
+          $("streamBadge").textContent = error.message;
+          $("streamBadge").className = "badge err";
+        }
+      }
+
+      function connectStream() {
+        if (stream) {
+          stream.close();
+        }
+        stream = new EventSource("/watch/stream");
+        $("streamBadge").textContent = "connecting";
+        $("streamBadge").className = "badge warn";
+        stream.addEventListener("results", (event) => {
+          $("streamBadge").textContent = "live";
+          $("streamBadge").className = "badge ok";
+          render(JSON.parse(event.data));
+        });
+        stream.onerror = () => {
+          $("streamBadge").textContent = "reconnecting";
+          $("streamBadge").className = "badge warn";
+        };
+      }
+
+      async function startImportWatch() {
+        const payload = {
+          location: $("importLocation").value,
+          database_path: $("databasePath").value.trim(),
+          documents_dir: $("documentsDir").value.trim(),
+          poll_interval: Number($("importPollInterval").value || "0.5"),
+          analyzer: $("importAnalyzer").value,
+          start_at_end: true,
+        };
+        await request("/watch/import-log/start", "POST", payload);
+        await refresh();
+        connectStream();
+      }
+
+      async function startCustomWatch() {
+        const payload = {
+          path: $("customPath").value.trim(),
+          poll_interval: Number($("customPollInterval").value || "0.5"),
+          start_at_end: $("startAtEnd").value === "true",
+          analyzer: $("customAnalyzer").value,
+        };
+        await request("/watch/start", "POST", payload);
+        await refresh();
+        connectStream();
+      }
+
+      async function stopWatch() {
+        await request("/watch/stop", "POST", {});
+        await refresh();
+      }
+
+      $("startImportButton").addEventListener("click", () =>
+        startImportWatch().catch((error) => alert(error.message)),
+      );
+      $("startCustomButton").addEventListener("click", () =>
+        startCustomWatch().catch((error) => alert(error.message)),
+      );
+      $("stopButton").addEventListener("click", () =>
+        stopWatch().catch((error) => alert(error.message)),
+      );
+      $("refreshButton").addEventListener("click", () =>
+        refresh().catch((error) => alert(error.message)),
+      );
+
+      connectStream();
+      refresh();
+      setInterval(() => refresh().catch(() => {}), 5000);
+    </script>
+  </body>
+</html>

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -335,12 +335,11 @@
           <div class="row single">
             <div>
               <label for="databasePath"
-                >Database path or folder for local file mode</label
+                >Database folder for local file mode</label
               >
               <div class="input-with-actions">
-                <input id="databasePath" placeholder="/path/to/MyFile.fmp12" />
-                <button type="button" id="browseDatabaseFileButton" class="secondary">File…</button>
-                <button type="button" id="browseDatabaseFolderButton" class="secondary">Folder…</button>
+                <input id="databasePath" placeholder="/path/to/database/folder" />
+                <button type="button" id="browseDatabaseFolderButton" class="secondary">Browse...</button>
               </div>
             </div>
           </div>
@@ -349,7 +348,7 @@
               <label for="documentsDir">Documents dir for server mode</label>
               <div class="input-with-actions">
                 <input id="documentsDir" placeholder="Documents folder" />
-                <button type="button" id="browseDocumentsDirButton" class="secondary">Browse…</button>
+                <button type="button" id="browseDocumentsDirButton" class="secondary">Browse...</button>
               </div>
             </div>
           </div>
@@ -713,17 +712,6 @@
         await refresh();
       }
 
-      async function browseDatabaseFile() {
-        const selectedPath = await pickPath(
-          "file",
-          $("databasePath").value.trim(),
-          "Select FileMaker file or Import.log file",
-        );
-        if (selectedPath) {
-          $("databasePath").value = selectedPath;
-        }
-      }
-
       async function browseDatabaseFolder() {
         const selectedPath = await pickPath(
           "directory",
@@ -754,9 +742,6 @@
       );
       $("refreshButton").addEventListener("click", () =>
         refresh().catch((error) => alert(error.message)),
-      );
-      $("browseDatabaseFileButton").addEventListener("click", () =>
-        browseDatabaseFile().catch((error) => alert(error.message)),
       );
       $("browseDatabaseFolderButton").addEventListener("click", () =>
         browseDatabaseFolder().catch((error) => alert(error.message)),

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -62,6 +62,19 @@
       .row.single {
         grid-template-columns: 1fr;
       }
+      .input-with-actions {
+        display: flex;
+        gap: 10px;
+        align-items: stretch;
+      }
+      .input-with-actions input {
+        flex: 1 1 auto;
+      }
+      .input-with-actions button {
+        width: auto;
+        flex: 0 0 auto;
+        white-space: nowrap;
+      }
       label {
         display: block;
         font-size: 12px;
@@ -323,13 +336,20 @@
               <label for="databasePath"
                 >Database path or folder for local file mode</label
               >
-              <input id="databasePath" placeholder="/path/to/MyFile.fmp12" />
+              <div class="input-with-actions">
+                <input id="databasePath" placeholder="/path/to/MyFile.fmp12" />
+                <button type="button" id="browseDatabaseFileButton" class="secondary">File…</button>
+                <button type="button" id="browseDatabaseFolderButton" class="secondary">Folder…</button>
+              </div>
             </div>
           </div>
           <div class="row">
             <div>
               <label for="documentsDir">Documents dir for server mode</label>
-              <input id="documentsDir" value="~/Documents" />
+              <div class="input-with-actions">
+                <input id="documentsDir" placeholder="Documents folder" />
+                <button type="button" id="browseDocumentsDirButton" class="secondary">Browse…</button>
+              </div>
             </div>
             <div>
               <label for="importPollInterval">Poll interval</label>
@@ -337,50 +357,13 @@
             </div>
           </div>
           <div class="button-row">
-            <button id="startImportButton">Start Import.log watch</button>
+            <button type="button" id="startImportButton">Start Import.log watch</button>
+            <button type="button" id="stopButton" class="danger">Stop watch</button>
+            <button type="button" id="refreshButton" class="secondary">Refresh</button>
           </div>
         </section>
 
         <section class="panel">
-          <h2>Custom File Watch</h2>
-          <div class="row single">
-            <div>
-              <label for="customPath">File path</label>
-              <input id="customPath" placeholder="/path/to/file.log" />
-            </div>
-          </div>
-          <div class="row">
-            <div>
-              <label for="customAnalyzer">Analyzer</label>
-              <select id="customAnalyzer">
-                <option value="import_log">Import.log issues</option>
-                <option value="import_log_unknown_attributes">
-                  Import.log unknown attributes
-                </option>
-              </select>
-            </div>
-            <div>
-              <label for="customPollInterval">Poll interval</label>
-              <input id="customPollInterval" value="0.5" />
-            </div>
-          </div>
-          <div class="row single">
-            <div>
-              <label for="startAtEnd">Start at end of file</label>
-              <select id="startAtEnd">
-                <option value="true">true</option>
-                <option value="false">false</option>
-              </select>
-            </div>
-          </div>
-          <div class="button-row">
-            <button id="startCustomButton">Start custom watch</button>
-            <button id="stopButton" class="danger">Stop watch</button>
-            <button id="refreshButton" class="secondary">Refresh</button>
-          </div>
-        </section>
-
-        <section class="panel full">
           <h2>Status</h2>
           <div id="statusGrid" class="status-grid"></div>
         </section>
@@ -400,6 +383,12 @@
     <script>
       const $ = (id) => document.getElementById(id);
       let stream = null;
+      let defaultsApplied = false;
+
+      function setStreamBadge(text, level = "") {
+        $("streamBadge").textContent = text;
+        $("streamBadge").className = `badge${level ? ` ${level}` : ""}`;
+      }
 
       function escapeHtml(value) {
         return String(value ?? "")
@@ -416,11 +405,42 @@
           body: body ? JSON.stringify(body) : null,
         });
         const text = await response.text();
-        const data = text ? JSON.parse(text) : {};
+        const contentType = response.headers.get("Content-Type") || "";
+        let data = {};
+        if (text) {
+          if (contentType.includes("application/json")) {
+            data = JSON.parse(text);
+          } else {
+            const summary = text.startsWith("<!DOCTYPE")
+              ? `Expected JSON from ${path}, got HTML instead.`
+              : text.slice(0, 200);
+            throw new Error(summary);
+          }
+        }
         if (!response.ok) {
           throw new Error(data.error || `HTTP ${response.status}`);
         }
         return data;
+      }
+
+      async function pickPath(selectionType, initialPath, title) {
+        const result = await request("/watch/pick-path", "POST", {
+          selection_type: selectionType,
+          initial_path: initialPath || "",
+          title: title || "",
+        });
+        return result.cancelled ? "" : (result.selected_path || "");
+      }
+
+      function applyDefaults(state) {
+        if (defaultsApplied) {
+          return;
+        }
+        const documentsDir = state.defaults?.documents_dir || "";
+        if (documentsDir && !$("documentsDir").value.trim()) {
+          $("documentsDir").value = documentsDir;
+        }
+        defaultsApplied = true;
       }
 
       function displayScriptName(importItem) {
@@ -510,7 +530,7 @@
           status === "with_errors"
             ? "warn"
             : status === "running"
-              ? "running"
+              ? "info"
               : "ok";
         const statusText =
           status === "with_errors"
@@ -572,6 +592,7 @@
       }
 
       function render(state) {
+        applyDefaults(state);
         renderStatus(state);
         renderStats(state.summary || {});
         renderImports(state.summary || {});
@@ -581,9 +602,15 @@
         try {
           const state = await request("/watch/results");
           render(state);
+          if (!state.running && stream) {
+            stream.close();
+            stream = null;
+            setStreamBadge("stream idle");
+          }
+          return state;
         } catch (error) {
-          $("streamBadge").textContent = error.message;
-          $("streamBadge").className = "badge err";
+          setStreamBadge(error.message, "err");
+          throw error;
         }
       }
 
@@ -592,16 +619,13 @@
           stream.close();
         }
         stream = new EventSource("/watch/stream");
-        $("streamBadge").textContent = "connecting";
-        $("streamBadge").className = "badge warn";
+        setStreamBadge("connecting", "warn");
         stream.addEventListener("results", (event) => {
-          $("streamBadge").textContent = "live";
-          $("streamBadge").className = "badge ok";
+          setStreamBadge("live", "ok");
           render(JSON.parse(event.data));
         });
         stream.onerror = () => {
-          $("streamBadge").textContent = "reconnecting";
-          $("streamBadge").className = "badge warn";
+          setStreamBadge("reconnecting", "warn");
         };
       }
 
@@ -619,28 +643,51 @@
         connectStream();
       }
 
-      async function startCustomWatch() {
-        const payload = {
-          path: $("customPath").value.trim(),
-          poll_interval: Number($("customPollInterval").value || "0.5"),
-          start_at_end: $("startAtEnd").value === "true",
-          analyzer: $("customAnalyzer").value,
-        };
-        await request("/watch/start", "POST", payload);
+      async function stopWatch() {
+        if (stream) {
+          stream.close();
+          stream = null;
+        }
+        setStreamBadge("stream idle");
+        await request("/watch/stop", "POST");
         await refresh();
-        connectStream();
       }
 
-      async function stopWatch() {
-        await request("/watch/stop", "POST", {});
-        await refresh();
+      async function browseDatabaseFile() {
+        const selectedPath = await pickPath(
+          "file",
+          $("databasePath").value.trim(),
+          "Select FileMaker file or Import.log file",
+        );
+        if (selectedPath) {
+          $("databasePath").value = selectedPath;
+        }
+      }
+
+      async function browseDatabaseFolder() {
+        const selectedPath = await pickPath(
+          "directory",
+          $("databasePath").value.trim() || $("documentsDir").value.trim(),
+          "Select database folder",
+        );
+        if (selectedPath) {
+          $("databasePath").value = selectedPath;
+        }
+      }
+
+      async function browseDocumentsDir() {
+        const selectedPath = await pickPath(
+          "directory",
+          $("documentsDir").value.trim(),
+          "Select Documents folder",
+        );
+        if (selectedPath) {
+          $("documentsDir").value = selectedPath;
+        }
       }
 
       $("startImportButton").addEventListener("click", () =>
         startImportWatch().catch((error) => alert(error.message)),
-      );
-      $("startCustomButton").addEventListener("click", () =>
-        startCustomWatch().catch((error) => alert(error.message)),
       );
       $("stopButton").addEventListener("click", () =>
         stopWatch().catch((error) => alert(error.message)),
@@ -648,9 +695,23 @@
       $("refreshButton").addEventListener("click", () =>
         refresh().catch((error) => alert(error.message)),
       );
+      $("browseDatabaseFileButton").addEventListener("click", () =>
+        browseDatabaseFile().catch((error) => alert(error.message)),
+      );
+      $("browseDatabaseFolderButton").addEventListener("click", () =>
+        browseDatabaseFolder().catch((error) => alert(error.message)),
+      );
+      $("browseDocumentsDirButton").addEventListener("click", () =>
+        browseDocumentsDir().catch((error) => alert(error.message)),
+      );
 
-      connectStream();
-      refresh();
+      refresh().then((state) => {
+        if (state?.running) {
+          connectStream();
+        } else {
+          setStreamBadge("stream idle");
+        }
+      }).catch(() => {});
       setInterval(() => refresh().catch(() => {}), 5000);
     </script>
   </body>

--- a/agent/scripts/companion_watch_ui.html
+++ b/agent/scripts/companion_watch_ui.html
@@ -526,7 +526,6 @@
         $("statusGrid").innerHTML = [
           ["Path", state.path || ""],
           ["File exists", String(Boolean(state.file_exists))],
-          ["Analyzer", state.analyzer?.type || ""],
           ["Poll interval", String(state.poll_interval ?? "")],
           ["Started at", formatTimestamp(state.started_at)],
           ["Last change", formatTimestamp(state.last_change_at)],
@@ -697,7 +696,6 @@
           database_path: $("databasePath").value.trim(),
           documents_dir: $("documentsDir").value.trim(),
           poll_interval: Number($("importPollInterval").value || "0.5"),
-          analyzer: "import_log",
           start_at_end: true,
         };
         await request("/watch/import-log/start", "POST", payload);


### PR DESCRIPTION
## Summary

This PR implements the Companion Watch UI for FileMaker `Import.log` monitoring including browser notifications for failed imports while the Watch UI page is open.

## Why

When we import script steps from the clipboard, then it is logged in the `Import.log` file. If script steps contain unknown parameters or values of parameters that are not known, there are errors in the log.

The goal is to make import monitoring clearer and more useful during working with `agentic-fm`:

- make watch controls reflect the actual running state
- visibility of failed imports without requiring the user to keep the Watch UI in the foreground

## Final functionality

### Watch UI

- the Watch UI is focused on `Import.log` monitoring
- local selection uses a folder path, since the watched file is always `Import.log`
- the poll interval control remains available
- the status panel shows the current watch state and latest error summary
- the grouped import view shows current and recent imports with error details

### Watch controls

- only `Start watch` is shown when no watch is active
- only `Stop watch` is shown while a watch is active
- the unused `Refresh` action has been removed

### Notifications

- browser notifications can be enabled directly from the Watch UI
- notifications are sent only while the Watch UI page is open
- notifications are triggered only when an import completes with errors
- each completed import produces at most one notification
- notification content is concise and formatted as:
  - `ScriptName (FileName.fmp12)`
  - import timestamp
  - error count

### Server behavior

- completed import lifecycle events now include the data needed by the Watch UI notification summary:
  - script name
  - source / solution name
  - database name
- the Watch UI startup URL is logged on server start
- the watch endpoint surface and documentation match the current UI behavior

## Testing

### Manual testing

- start the Companion Server
- open `/watch/ui`
- start an `Import.log` watch in both:
  - server mode
  - local mode
- verify that:
  - only `Start watch` is visible before a watch starts
  - only `Stop watch` is visible while a watch is running
- trigger a successful import and confirm:
  - no notification is shown
- trigger an import with errors and confirm:
  - a browser notification is shown while the page is open
  - the notification uses the format:
    - `ScriptName (FileName.fmp12)`
    - timestamp
    - error count
- confirm the import summary and status area update correctly
- confirm local folder selection resolves the correct `Import.log`

### Verification notes

- browser notification flow verified when both:
  - site permission is allowed in the browser
  - browser app notifications are enabled in the OS