### PR TITLE
Small fixes: saxmlpreview Label fallback and fetch_docs future annotations

### DIFF
--- a/.cursor/skills/script-preview/scripts/saxmlpreview.py
+++ b/.cursor/skills/script-preview/scripts/saxmlpreview.py
@@ -234,6 +234,10 @@ def _render_params(step):
                 if layout_ref is not None:
                     lname = layout_ref.get('name', '')
                     parts.append(f'"{lname}"')
+                else:
+                    label_el = container_el.find('Label')
+                    if label_el is not None and label_el.text:
+                        parts.append(label_el.text)
 
         # ── Animation ─────────────────────────────────────────────────────────
         elif ptype == 'Animation':

--- a/agent/docs/filemaker/fetch_docs.py
+++ b/agent/docs/filemaker/fetch_docs.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 """
 Fetch FileMaker Pro reference documentation from the Claris help site.
 


### PR DESCRIPTION
## Summary

Two small unrelated fixes batched for convenience:

- **`saxmlpreview.py`** — when rendering a step that references a layout, fall back to the `<Label>` text element if no `<LayoutReference>` is present. Without this, label-only layout references (e.g. "original layout") rendered as empty.
- **`fetch_docs.py`** — add `from __future__ import annotations` for forward-reference compatibility.

## Test plan

- [ ] Run `saxmlpreview.py` against a script with a step using a label-only layout reference; confirm the label text appears in preview
- [ ] Run `fetch_docs.py` and confirm no syntax/runtime errors from the new import

🤖 Generated with [Claude Code](https://claude.com/claude-code)