### PR TITLE
Ignore .claude/worktrees/ — agent worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ agent/sandbox/
 .private/
 .venv/
 .cursor/in-development/
+.claude/worktrees/
 external_tools/
 plans/
 


### PR DESCRIPTION
## Summary

Claude Code creates ephemeral git worktrees under `.claude/worktrees/` when an agent runs in isolation mode. These are local-only artifacts and should never be tracked. Adds the directory to `.gitignore` alongside the existing `.cursor/in-development/` entry.

## Test plan

- [ ] After this lands, run an isolated Claude Code agent and confirm the resulting `.claude/worktrees/<name>/` does not appear in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)