### PR TITLE
fmlint: add SL017 (leftover-template-scaffolding)

### DIFF
--- a/SL_FORK.md
+++ b/SL_FORK.md
@@ -1,0 +1,56 @@
+# Special-Lite Internal Fork
+
+This repository is **Special-Lite's internal fork** of [petrowsky/agentic-fm](https://github.com/petrowsky/agentic-fm). It is consumed as a git submodule from `special-lite/sl-inventory` and (eventually) other SL FileMaker module repos.
+
+## Why a fork
+
+Two reasons:
+
+1. **SL-specific lint rules and gotchas** — the upstream project is shared with other teams. Patterns that bit us repeatedly during SL Inventory audit-fix passes (Pattern A polarity bugs, empty PSOS parameter calcs, etc.) live as fmlint rules here. See `agent/fmlint/` for the rule sources and `docs/patterns/` in sl-inventory for the prose write-ups.
+
+2. **Bug fixes we need today** — when we hit a bug that's been bothering us for weeks (e.g., the `tx_perform_script_on_server` / `tx_new_window` translator gap in `fm_xml_to_snippet.py`) we ship the fix here immediately rather than waiting on an upstream PR review cycle.
+
+## Do not PR changes back to `petrowsky/agentic-fm`
+
+**This is the firm rule.** Changes made on this fork stay on this fork. Upstream improvements may be pulled in, but our changes are not sent up.
+
+The exception: if upstream itself opens a discussion about a feature that overlaps with something we've built, we can share our implementation as a reference. But no automated/proactive PR-back.
+
+## Pulling upstream improvements
+
+```bash
+cd path/to/sl-inventory/agentic-fm
+git fetch upstream                    # `upstream` should already point at petrowsky/agentic-fm
+git checkout main
+git merge upstream/main               # or rebase; merge is fine
+# resolve any conflicts (rare — divergence is in fmlint/ and a few translator additions)
+git push origin main
+```
+
+After pushing to the fork's `main`, bump the submodule pointer in sl-inventory:
+
+```bash
+cd path/to/sl-inventory
+git add agentic-fm
+git commit -m "submodule: bump agentic-fm to pull upstream changes through DATE"
+```
+
+## Intentional divergences from upstream
+
+A short ledger of what differs from `petrowsky/agentic-fm`. Update this whenever a new SL-only change lands.
+
+| Date | Change | Reason |
+|---|---|---|
+| 2026-05-15 | `agent/scripts/fm_xml_to_snippet.py` — added `tx_perform_script_on_server` and `tx_new_window` translators | Catalog-driven generic translator silently dropped PSOS script reference + parameter calc, and dropped New Window's Style/Name/Bounds/Options. Both broke transactional workflows on every SaXML → fmxmlsnippet round-trip. |
+| 2026-05-15 | `agent/catalogs/step-catalog-en.json` — added `CurrentLayout`, `LayoutNameByCalculation`, `LayoutNumberByCalculation` to the `LayoutDestination` enum | Verified via FM round-trip 2026-05-14 (see sl-inventory `docs/patterns/fm-fmxmlsnippet-gotchas.md` §1). Upstream catalog only listed `SelectedLayout`. |
+| 2026-05-15 | `agent/fmlint/rules/sl_*` — SL-specific lint rules | Pattern A polarity bug (`Set Error Capture [OFF]` before record-mutating step) and empty PSOS parameter calc are both silent-failure classes that have bitten this codebase 3+ times. Lint catches them deterministically. |
+
+## Cross-references
+
+- **SL FileMaker patterns and gotchas** → [`sl-inventory/docs/patterns/`](https://fmdev.special-lite.com:8080/dev/inventory/patterns/) (hosted in sl-docs)
+- **SL team workflow rules** → [`sl-inventory/CLAUDE.md`](../CLAUDE.md) and [`sl-docs/dev/team-workflow.md`](https://fmdev.special-lite.com:8080/dev/team-workflow/)
+- **Upstream project** → [`petrowsky/agentic-fm`](https://github.com/petrowsky/agentic-fm)
+
+## For Claude sessions opening this folder cold
+
+If you're an agent reading this on session start: this is a fork. The SL-specific rules in [`sl-inventory/CLAUDE.md`](../CLAUDE.md) (`No subagents for FM script generation`, etc.) apply. Read [`sl-inventory/docs/patterns/`](../docs/patterns/) before editing any FM scripts. Do not propose PRs back to petrowsky/agentic-fm.

--- a/agent/catalogs/step-catalog-en.json
+++ b/agent/catalogs/step-catalog-en.json
@@ -2764,10 +2764,11 @@
         "defaultValue": "SelectedLayout",
         "enumValues": [
           "SelectedLayout",
-          "OriginalLayout",
+          "CurrentLayout",
           "LayoutNameByCalculation",
           "LayoutNumberByCalculation"
-        ]
+        ],
+        "notes": "CurrentLayout (NOT 'OriginalLayout') is FM's actual enum for the HR 'Layout: <original layout>' default — verified via FM round-trip 2026-05-14. When LayoutDestination=CurrentLayout, omit the <Layout> child element entirely; including one breaks the binding silently on paste."
       },
       {
         "xmlElement": "Layout",
@@ -4314,8 +4315,12 @@
         "required": false,
         "defaultValue": "SelectedLayout",
         "enumValues": [
-          "SelectedLayout"
-        ]
+          "SelectedLayout",
+          "CurrentLayout",
+          "LayoutNameByCalculation",
+          "LayoutNumberByCalculation"
+        ],
+        "notes": "CurrentLayout = the layout active when the step runs (HR 'Layout: <original layout>') — verified via FM round-trip 2026-05-14. When LayoutDestination=CurrentLayout, omit the <Layout> child element entirely."
       },
       {
         "xmlElement": "Calculation",

--- a/agent/catalogs/step-catalog-en.json
+++ b/agent/catalogs/step-catalog-en.json
@@ -3112,6 +3112,15 @@
         "notes": "Flag-style: shown as \"New window\" when True. Enables window params and NewWndStyles. See window-enums.md."
       },
       {
+        "xmlElement": "Restore",
+        "type": "boolean",
+        "hrLabel": null,
+        "xmlAttr": "state",
+        "required": false,
+        "defaultValue": "False",
+        "notes": "Not surfaced in HR. The canonical default is \"False\" — verified via FM round-trip 2026-05-15. Emitting state=\"True\" causes FM to render the step's HR as if \"Show only related records\" were checked, even when <Option state=\"False\"/>. Always emit state=\"False\" unless a specific need to override is documented."
+      },
+      {
         "xmlElement": "NewWndStyles",
         "type": "complex",
         "hrLabel": null,
@@ -3125,7 +3134,8 @@
         "xmlAttr": "value",
         "required": false,
         "defaultValue": "None",
-        "notes": "FileMaker Go only. See animation-enums.md for values."
+        "omitWhenDefault": true,
+        "notes": "FileMaker Go only. See animation-enums.md for values. Omit the <Animation> element entirely when the value would be \"None\" — emitting <Animation value=\"None\"/> produces a stray \"External\" prefix in HR (verified via FM round-trip 2026-05-15)."
       }
     ],
     "hrSignature": "[ Show only related records ; Match found set ; From table: \"table\" ; Using layout: layout ; New window ]",

--- a/agent/fmlint/rules/__init__.py
+++ b/agent/fmlint/rules/__init__.py
@@ -7,3 +7,4 @@ from . import references  # noqa: F401
 from . import best_practices  # noqa: F401
 from . import calculations  # noqa: F401
 from . import live_eval  # noqa: F401
+from . import sl_inventory  # noqa: F401  — SL fork additions (see SL_FORK.md)

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -329,3 +329,392 @@ class PsosSelfRecursionEmptyParameter(LintRule):
         # sanitized output (renders as "⚠️ PARAMETER 'Parameter' NOT
         # PARSED ⚠️"), so we skip HR mode. XML mode is authoritative.
         return []
+
+
+# ---------------------------------------------------------------------------
+# SL003 — banned-readme-doc-block
+# ---------------------------------------------------------------------------
+
+@rule
+class BannedReadmeDocBlock(LintRule):
+    """Flag the disabled <Step name="Insert Text"> with <Field>$README</Field>
+    pattern that some legacy scripts used for header documentation
+    (PARAMETER FORMAT / NOTES / HISTORY duplicates).
+
+    Banned by team convention 2026-05-13 — "no other scripts are documenting
+    like this; let the code speak for itself." The legitimate header
+    comments (# # PURPOSE / # # NOTES / # # HISTORY / # # TODO) are the
+    canonical location.
+    """
+
+    rule_id = "SL003"
+    name = "banned-readme-doc-block"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        for idx, step in enumerate(parse_result.steps):
+            if step.get("name", "") != "Insert Text":
+                continue
+            if step.get("enable", "True") != "False":
+                continue  # only flag the disabled-step variant of the pattern
+            field = step.find("Field")
+            if field is None or field.text != "$README":
+                continue
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "Disabled Insert Text step targeting $README — banned "
+                    "doc-block pattern (PARAMETER FORMAT / NOTES / HISTORY "
+                    "duplicates). Banned by team convention 2026-05-13."
+                ),
+                line=idx + 1,
+                fix_hint=(
+                    "Remove the disabled <Step name=\"Insert Text\"> with "
+                    "<Field>$README</Field>. Move any genuinely useful "
+                    "content into the # # PURPOSE / # # NOTES comment "
+                    "block at the top of the script."
+                ),
+            ))
+        return diagnostics
+
+    def check_hr(self, lines, catalog, context, config):
+        # HR sanitized output renders the disabled Insert Text as a
+        # `// Insert Text [...]` line, which is a strong textual signal.
+        sev = self.severity(config)
+        diagnostics = []
+        for ln in lines:
+            raw = (ln.raw or "").strip()
+            if raw.startswith("// Insert Text") and "$README" in raw:
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "Disabled Insert Text step targeting $README — "
+                        "banned doc-block pattern. Banned by team "
+                        "convention 2026-05-13."
+                    ),
+                    line=ln.line_number,
+                    fix_hint=(
+                        "Remove the disabled Insert Text step. Move any "
+                        "useful content into the # # PURPOSE / # # NOTES "
+                        "comment block at the top of the script."
+                    ),
+                ))
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL004 — boilerplate-placeholder
+# ---------------------------------------------------------------------------
+
+_BOILERPLATE_RE = re.compile(
+    r"YYYY-MM-DD\s+by\s+FName\s+LName",
+    re.IGNORECASE,
+)
+
+
+@rule
+class BoilerplatePlaceholder(LintRule):
+    """Flag the uncleaned template-boilerplate "Modified" placeholder
+    line that TMPL_NewScript ships with: "# Modified: YYYY-MM-DD by
+    FName LName [REF#]".
+
+    Should be replaced with a real history entry (or deleted) when the
+    script is first modified after creation. Bit the 2026-05-15 audit
+    where it appeared in 5 scripts that had been edited since creation
+    but never had this line cleaned up.
+    """
+
+    rule_id = "SL004"
+    name = "boilerplate-placeholder"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml", "hr"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        for idx, step in enumerate(parse_result.steps):
+            if step.get("name", "") != "# (comment)":
+                continue
+            text_el = step.find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            if _BOILERPLATE_RE.search(text_el.text):
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "Uncleaned template-boilerplate Modified line "
+                        "(\"YYYY-MM-DD by FName LName [REF#]\"). Replace "
+                        "with a real history entry or delete."
+                    ),
+                    line=idx + 1,
+                    fix_hint=(
+                        "Replace this # (comment) step's text with a real "
+                        "Modified entry: "
+                        "\"Modified: 2026-MM-DD by <name> / Claude — "
+                        "<what changed and why>.\""
+                    ),
+                ))
+        return diagnostics
+
+    def check_hr(self, lines, catalog, context, config):
+        sev = self.severity(config)
+        diagnostics = []
+        for ln in lines:
+            raw = ln.raw or ""
+            if _BOILERPLATE_RE.search(raw):
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "Uncleaned template-boilerplate Modified line. "
+                        "Replace with a real history entry or delete."
+                    ),
+                    line=ln.line_number,
+                    fix_hint=(
+                        "Replace with a real Modified entry or remove the "
+                        "comment step entirely."
+                    ),
+                ))
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL005 — missing-pseudo-loop-markers
+# ---------------------------------------------------------------------------
+
+@rule
+class MissingPseudoLoopMarkers(LintRule):
+    """Flag scripts that have a top-level Loop step but lack the
+    canonical BEGIN PSEUDO LOOP / END PSEUDO LOOP marker comments.
+
+    The TMPL_NewScript and TMPL_NewScript - Transactions templates both
+    wrap the script body in a "pseudo-loop" — a Loop step that runs once
+    and uses Exit Loop If steps for early-exit control flow. The marker
+    comment blocks make this structure scannable in Script Workspace:
+
+        # =====================================================
+        # BEGIN PSEUDO LOOP
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        Loop [ ... ]
+           ...body...
+        End Loop
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        # END PSEUDO LOOP
+        # =====================================================
+
+    Missing markers usually means the script is using a Loop but not
+    following the template convention (or was hand-rolled before the
+    convention existed). Surfaced 2026-05-15 in the RefreshPayload
+    rebuild pass.
+    """
+
+    rule_id = "SL005"
+    name = "missing-pseudo-loop-markers"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+
+        # Does the script have any Loop step?
+        has_loop = any(s.get("name", "") == "Loop" for s in parse_result.steps)
+        if not has_loop:
+            return []
+
+        # Search comment text for the BEGIN/END markers
+        has_begin_marker = False
+        has_end_marker = False
+        for step in parse_result.steps:
+            if step.get("name", "") != "# (comment)":
+                continue
+            text_el = step.find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            txt = text_el.text.strip().upper()
+            # Accept the typo "PSUEDO" too — older scripts have it
+            if txt.startswith("BEGIN PSEUDO LOOP") or txt.startswith("BEGIN PSUEDO LOOP"):
+                has_begin_marker = True
+            elif txt.startswith("END PSEUDO LOOP") or txt.startswith("END PSUEDO LOOP"):
+                has_end_marker = True
+
+        diagnostics = []
+        if not has_begin_marker:
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "Script has a Loop step but no \"BEGIN PSEUDO LOOP\" "
+                    "marker comment block. The TMPL_NewScript templates "
+                    "wrap the pseudo-loop in marker comments for "
+                    "scannability."
+                ),
+                line=0,
+                fix_hint=(
+                    "Add three # (comment) steps immediately before the "
+                    "Loop step: a row of \"=\" characters, the text "
+                    "\"BEGIN PSEUDO LOOP\", and a row of \"~\" characters."
+                ),
+            ))
+        if not has_end_marker:
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "Script has a Loop step but no \"END PSEUDO LOOP\" "
+                    "marker comment block."
+                ),
+                line=0,
+                fix_hint=(
+                    "Add three # (comment) steps immediately after the "
+                    "matching End Loop step: a row of \"~\" characters, "
+                    "the text \"END PSEUDO LOOP\", and a row of \"=\" "
+                    "characters."
+                ),
+            ))
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL006 — script-top-global-allow-or-capture
+# ---------------------------------------------------------------------------
+
+@rule
+class ScriptTopGlobalAllowOrCapture(LintRule):
+    """Flag Allow User Abort or Set Error Capture steps placed at the
+    script top level (before the outer Loop), in scripts that also have
+    a Loop. The TMPL_NewScript convention places these steps INSIDE the
+    pseudo-loop where they apply to specific risky steps — not as
+    "global preamble" before the loop starts.
+
+    Top-level globals were the old hand-rolled pattern from before the
+    template existed. Bit the 2026-05-15 RefreshPayload rebuild pass.
+
+    Scripts that have NO Loop (e.g., thin Open*Dialog wrappers like
+    INV_OpenNewItemDialog) are exempt — for those, top-level
+    Allow User Abort / Set Error Capture is the intentional pattern.
+    """
+
+    rule_id = "SL006"
+    name = "script-top-global-allow-or-capture"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+
+        # Find the index of the first Loop step. If none, the script is
+        # a thin wrapper and this rule doesn't apply.
+        loop_idx = None
+        for idx, step in enumerate(parse_result.steps):
+            if step.get("name", "") == "Loop":
+                loop_idx = idx
+                break
+        if loop_idx is None:
+            return []
+
+        # Scan steps BEFORE the Loop for Allow User Abort / Set Error Capture
+        diagnostics = []
+        for idx in range(loop_idx):
+            name = parse_result.steps[idx].get("name", "")
+            if name in ("Allow User Abort", "Set Error Capture"):
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        f"'{name}' step appears at script top level "
+                        f"(before the outer Loop). The TMPL_NewScript "
+                        f"templates don't use top-level globals — these "
+                        f"steps belong INSIDE the pseudo-loop, paired with "
+                        f"specific risky steps that need them."
+                    ),
+                    line=idx + 1,
+                    fix_hint=(
+                        f"Remove this top-level {name} step. If a risky "
+                        f"step inside the loop needs error suppression, "
+                        f"wrap THAT step with a Set Error Capture [On] / "
+                        f"CreateEventObjectFmErrorsOnly / [Off] pair."
+                    ),
+                ))
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL009 — redundant-else-label
+# ---------------------------------------------------------------------------
+
+_ELSE_LABEL_RE = re.compile(r"^//\s*Else\s*$", re.IGNORECASE)
+
+
+@rule
+class RedundantElseLabel(LintRule):
+    """Flag a # (comment) step with text "// Else" immediately preceding
+    a bare Else step.
+
+    Banned by team convention 2026-05-14 ("the Else step itself is the
+    label; the comment adds nothing"). The blank-line-above-Else
+    convention (FM script style Rule 1) provides the visual separation
+    the // Else label was meant to add.
+    """
+
+    rule_id = "SL009"
+    name = "redundant-else-label"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        steps = parse_result.steps
+        for idx in range(len(steps) - 1):
+            cur = steps[idx]
+            nxt = steps[idx + 1]
+            if cur.get("name", "") != "# (comment)":
+                continue
+            if nxt.get("name", "") != "Else":
+                continue
+            text_el = cur.find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            if _ELSE_LABEL_RE.match(text_el.text.strip()):
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "Redundant \"// Else\" comment immediately above "
+                        "a bare Else step. Banned by team convention "
+                        "2026-05-14 — the Else step itself is the label."
+                    ),
+                    line=idx + 1,
+                    fix_hint=(
+                        "Remove the # (comment) step. If visual separation "
+                        "is wanted, the blank-line-above-Else convention "
+                        "(empty # (comment) step) is the canonical way."
+                    ),
+                ))
+        return diagnostics

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -1,0 +1,331 @@
+"""SL-specific FMLint rules (SL001+).
+
+These rules were added by Special-Lite's internal fork of agentic-fm to
+catch silent-failure patterns that have bitten our codebase repeatedly.
+They are general FM correctness rules — not SL-business-logic-specific —
+but they live in this file (rather than in best_practices.py) so they
+remain clearly identifiable as fork additions and can be removed cleanly
+if upstream ever adopts equivalent checks.
+
+See agentic-fm/SL_FORK.md for fork rationale and divergence ledger.
+"""
+
+import re
+
+from ..engine import rule, LintRule
+from ..types import Diagnostic, Severity
+
+
+# Steps that mutate records or change find/layout state in a way that can
+# silently fail without dialog suppression. The canonical SL_Core wrapper
+# turns Set Error Capture [On] BEFORE these steps and Off AFTER (paired
+# with CreateEventObjectFmErrorsOnly). Seeing Set Error Capture [Off]
+# immediately followed by one of these is the Pattern A polarity bug.
+_RISKY_STEPS = frozenset({
+    "Enter Find Mode",
+    "Perform Find",
+    "New Record/Request",
+    "Set Field",
+    "Set Field By Name",
+    "Open Transaction",
+    # NOTE: Commit Transaction is deliberately omitted. The canonical
+    # TMPL_NewScript - Transactions tail places Set Error Capture [Off]
+    # immediately before Commit Transaction as the final-cleanup pattern
+    # (any errors at outer-commit time should surface as FM dialogs, not
+    # get captured into an event object). Flagging this would generate
+    # false positives on every transactional workflow.
+    "Delete Record/Request",
+    "Delete All Records",
+    "Replace Field Contents",
+    "Commit Records/Requests",
+    "Insert from URL",
+    "Go to Object",
+    "Go to Layout",
+    "Go to Related Record",
+    "Perform JavaScript in Web Viewer",
+    "Refresh Portal",
+})
+
+# Steps that are part of the canonical closer pattern. If a Set Error
+# Capture [Off] is preceded by one of these (within 2 steps), it's the
+# legitimate closer — not Pattern A.
+_CANONICAL_CLOSER_HINTS = (
+    "CreateEventObjectFmErrorsOnly",
+)
+
+
+def _is_set_error_off_xml(step) -> bool:
+    if step.get("name", "") != "Set Error Capture":
+        return False
+    set_el = step.find("Set")
+    if set_el is None:
+        return False
+    return set_el.get("state", "").lower() == "false"
+
+
+def _is_set_error_off_hr(ln) -> bool:
+    if ln.step_name != "Set Error Capture":
+        return False
+    bracket = (ln.bracket_content or "").lower()
+    return "off" in bracket
+
+
+def _previous_step_is_canonical_closer_xml(steps, idx: int) -> bool:
+    """Look at the 1–2 steps immediately preceding `idx` (skipping comments).
+    Return True if any of them sets a variable from CreateEventObjectFmErrorsOnly,
+    which means the Set Error Capture [Off] at idx is the canonical closer."""
+    looked = 0
+    j = idx - 1
+    while j >= 0 and looked < 2:
+        name = steps[j].get("name", "")
+        if name == "# (comment)":
+            j -= 1
+            continue
+        looked += 1
+        if name == "Set Variable":
+            for calc in steps[j].iter("Calculation"):
+                if calc.text and any(h in calc.text for h in _CANONICAL_CLOSER_HINTS):
+                    return True
+        j -= 1
+    return False
+
+
+def _next_step_xml(steps, idx: int):
+    """Return the next non-comment step after `idx`, or None."""
+    for j in range(idx + 1, len(steps)):
+        if steps[j].get("name", "") != "# (comment)":
+            return steps[j], j
+    return None, -1
+
+
+def _previous_step_is_canonical_closer_hr(lines, idx: int) -> bool:
+    looked = 0
+    j = idx - 1
+    while j >= 0 and looked < 2:
+        if lines[j].step_name == "# (comment)":
+            j -= 1
+            continue
+        looked += 1
+        if lines[j].step_name == "Set Variable":
+            content = (lines[j].bracket_content or "") + " " + (lines[j].raw or "")
+            if any(h in content for h in _CANONICAL_CLOSER_HINTS):
+                return True
+        j -= 1
+    return False
+
+
+def _next_line_hr(lines, idx: int):
+    for j in range(idx + 1, len(lines)):
+        if lines[j].step_name != "# (comment)":
+            return lines[j], j
+    return None, -1
+
+
+# ---------------------------------------------------------------------------
+# SL001 — set-error-capture-off-before-risky-step (Pattern A)
+# ---------------------------------------------------------------------------
+
+@rule
+class SetErrorCaptureOffBeforeRiskyStep(LintRule):
+    """Flag Set Error Capture [Off] that precedes a record-mutating step.
+
+    The SL_Core canonical wrapper turns error capture **On** BEFORE the
+    risky step (so FM errors are suppressed and captured into an event
+    object) and Off AFTER (paired with CreateEventObjectFmErrorsOnly).
+    Seeing Off→risky-step is almost always a polarity bug — the developer
+    typed Off where they meant On. With Off, FM throws its user-facing
+    dialog instead of capturing the error, AND the downstream
+    CreateEventObjectFmErrorsOnly call may not capture cleanly.
+
+    This bug has bitten the SL Inventory codebase 3+ times (PR 5 audit
+    2026-05-14; current audit 2026-05-15 at scripts 1041 and 958). The
+    rule catches it deterministically.
+    """
+
+    rule_id = "SL001"
+    name = "set-error-capture-off-before-risky-step"
+    category = "sl_fork"
+    default_severity = Severity.ERROR
+    formats = {"xml", "hr"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+
+        sev = self.severity(config)
+        diagnostics = []
+        steps = parse_result.steps
+
+        for idx, step in enumerate(steps):
+            if not _is_set_error_off_xml(step):
+                continue
+            # If the previous non-comment step looks like the canonical
+            # closer (Set Variable from CreateEventObjectFmErrorsOnly),
+            # this Off is the closer — not Pattern A.
+            if _previous_step_is_canonical_closer_xml(steps, idx):
+                continue
+            # Look at the next non-comment step.
+            next_step, next_idx = _next_step_xml(steps, idx)
+            if next_step is None:
+                continue
+            next_name = next_step.get("name", "")
+            if next_name in _RISKY_STEPS:
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        f"Set Error Capture [Off] is immediately followed by "
+                        f"'{next_name}'. This looks like a polarity bug "
+                        f"(Pattern A) — the wrapper should open with "
+                        f"Set Error Capture [On] before the risky step, "
+                        f"not [Off]. With [Off], FM throws its dialog AND "
+                        f"the downstream CreateEventObjectFmErrorsOnly call "
+                        f"may not capture cleanly."
+                    ),
+                    line=idx + 1,
+                    fix_hint=(
+                        "Change the Set Error Capture state from Off to On. "
+                        "The Off step should appear AFTER the risky step "
+                        "(paired with Set Variable [ $eventObjectFmErrorsOnly ; "
+                        "CreateEventObjectFmErrorsOnly ]) as the canonical closer."
+                    ),
+                ))
+
+        return diagnostics
+
+    def check_hr(self, lines, catalog, context, config):
+        sev = self.severity(config)
+        diagnostics = []
+
+        for idx, ln in enumerate(lines):
+            if not _is_set_error_off_hr(ln):
+                continue
+            if _previous_step_is_canonical_closer_hr(lines, idx):
+                continue
+            next_line, _ = _next_line_hr(lines, idx)
+            if next_line is None:
+                continue
+            if next_line.step_name in _RISKY_STEPS:
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        f"Set Error Capture [Off] is immediately followed by "
+                        f"'{next_line.step_name}'. This looks like a polarity "
+                        f"bug (Pattern A) — should be [On] before the risky step."
+                    ),
+                    line=ln.line_number,
+                    fix_hint=(
+                        "Change the Set Error Capture state from Off to On. "
+                        "The Off step should appear AFTER the risky step as "
+                        "the canonical closer (paired with CreateEventObjectFmErrorsOnly)."
+                    ),
+                ))
+
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL002 — psos-self-recursion-empty-parameter
+# ---------------------------------------------------------------------------
+
+# A PSOS step that uses Get(ScriptName) as its script reference is the
+# canonical self-recursion idiom for transactional workflows. If the
+# parameter Calculation is empty/missing, the server-side dispatch runs
+# with no parameter and the workflow silently re-runs in a broken state.
+# See sl-inventory/docs/patterns/fm-fmxmlsnippet-gotchas.md §5 for the
+# full bug history (surfaced 2026-05-05 and 2026-05-06).
+
+_SCRIPT_NAME_RE = re.compile(r"Get\s*\(\s*ScriptName\s*\)", re.IGNORECASE)
+
+
+@rule
+class PsosSelfRecursionEmptyParameter(LintRule):
+    """Flag Perform Script on Server with Get(ScriptName) self-reference
+    but a missing or empty Parameter calculation.
+
+    Transactional workflow scripts use the canonical PSOS self-recursion
+    pattern: "By name" + Get(ScriptName) + $scriptParameterObject (or
+    Get(ScriptParameter)) parameter calc. If the parameter is empty, the
+    server-side instance receives nothing — every required field appears
+    missing on validation, and the workflow surfaces a confusing
+    "Required parameter(s) missing..." error from the SERVER side even
+    though the client-side caller passed a complete payload.
+
+    This bug has bitten the SL Inventory codebase 2+ times (PR #15
+    2026-05-05; PR #19 2026-05-06). Triple-checking the Parameter calc
+    is non-empty whenever the PSOS reference is Get(ScriptName) closes
+    the silent-failure window for good.
+    """
+
+    rule_id = "SL002"
+    name = "psos-self-recursion-empty-parameter"
+    category = "sl_fork"
+    default_severity = Severity.ERROR
+    formats = {"xml"}  # PSOS internals are hard to detect reliably from HR
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+
+        sev = self.severity(config)
+        diagnostics = []
+
+        for idx, step in enumerate(parse_result.steps):
+            if step.get("name", "") != "Perform Script on Server":
+                continue
+
+            # Detect self-recursion: <Calculated> child whose CDATA matches
+            # Get(ScriptName).
+            calculated = step.find("Calculated")
+            if calculated is None:
+                continue  # "From list" mode — different concern, skip
+            ref_calc = calculated.find("Calculation")
+            if ref_calc is None or ref_calc.text is None:
+                continue
+            if not _SCRIPT_NAME_RE.search(ref_calc.text):
+                continue
+
+            # Self-recursion confirmed. Now check the Parameter Calculation —
+            # it's the top-level <Calculation> direct child of <Step>
+            # (siblings to <Calculated> and <WaitForCompletion>).
+            param_calc = None
+            for child in step:
+                if child.tag == "Calculation":
+                    param_calc = child
+                    break
+
+            param_text = (param_calc.text or "").strip() if param_calc is not None else ""
+
+            if not param_text:
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "Perform Script on Server uses Get(ScriptName) "
+                        "(self-recursion idiom) but the Parameter "
+                        "calculation is missing or empty. The server-side "
+                        "instance will receive no parameter, and the "
+                        "workflow will silently re-run with all required "
+                        "fields appearing missing. This is a known "
+                        "silent-failure foot-gun — see "
+                        "sl-inventory/docs/patterns/fm-fmxmlsnippet-gotchas.md §5."
+                    ),
+                    line=idx + 1,
+                    fix_hint=(
+                        "Set the Parameter calculation to $scriptParameterObject "
+                        "(SL project convention) or Get(ScriptParameter) "
+                        "(template default). Both are functionally equivalent "
+                        "and either is correct."
+                    ),
+                ))
+
+        return diagnostics
+
+    def check_hr(self, lines, catalog, context, config):
+        # PSOS parameter contents aren't reliably visible in the HR
+        # sanitized output (renders as "⚠️ PARAMETER 'Parameter' NOT
+        # PARSED ⚠️"), so we skip HR mode. XML mode is authoritative.
+        return []

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -718,3 +718,193 @@ class RedundantElseLabel(LintRule):
                     ),
                 ))
         return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# SL010 — pjsiwv-must-be-wrapped
+# ---------------------------------------------------------------------------
+
+@rule
+class PjsiwvMustBeWrapped(LintRule):
+    """Flag Perform JavaScript in Web Viewer steps that aren't wrapped
+    with the canonical Set Error Capture pattern.
+
+    PJSIWV is silent-failure-prone: if the target object name is wrong,
+    if the JS function name doesn't exist, or if the WV is in a bad
+    state, the step fails with no diagnostic and the caller has no way
+    to know. The canonical wrapper turns Error Capture On before the
+    step, captures FM errors via CreateEventObjectFmErrorsOnly, turns
+    Error Capture Off after, and checks $fmErrorCode for a non-zero
+    result.
+
+    Surfaced 2026-05-15 — a helper script written during the SL
+    Inventory audit missed wrapping the second of two PJSIWV calls in
+    INV_StandardCost_RefreshPayload due to a substring-find bug. Trevor
+    caught it on paste review. Adding this rule means the next time a
+    PJSIWV slips through unwrapped (Claude-generated or human-typed),
+    fmlint catches it instead of relying on human review.
+
+    Heuristic: the step immediately before a PJSIWV (skipping
+    # (comment) steps) must be Set Error Capture with state="True",
+    AND the next non-comment step after must be Set Variable whose
+    value calc references CreateEventObjectFmErrorsOnly.
+    """
+
+    rule_id = "SL010"
+    name = "pjsiwv-must-be-wrapped"
+    category = "sl_fork"
+    default_severity = Severity.ERROR
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        steps = parse_result.steps
+        for idx, step in enumerate(steps):
+            if step.get("name", "") != "Perform JavaScript in Web Viewer":
+                continue
+
+            # Walk backwards skipping comments to find the previous
+            # executable step.
+            prev_idx = idx - 1
+            while prev_idx >= 0 and steps[prev_idx].get("name", "") == "# (comment)":
+                prev_idx -= 1
+            if prev_idx < 0:
+                diagnostics.append(self._diag(sev, idx, "no preceding step"))
+                continue
+
+            prev = steps[prev_idx]
+            if prev.get("name", "") != "Set Error Capture":
+                diagnostics.append(self._diag(sev, idx, f"preceded by '{prev.get('name', '?')}', not Set Error Capture"))
+                continue
+
+            set_el = prev.find("Set")
+            if set_el is None or set_el.get("state", "False") != "True":
+                diagnostics.append(self._diag(sev, idx, "preceded by Set Error Capture but state is not True"))
+                continue
+
+            # Confirm the closing side
+            next_idx = idx + 1
+            while next_idx < len(steps) and steps[next_idx].get("name", "") == "# (comment)":
+                next_idx += 1
+            if next_idx >= len(steps):
+                diagnostics.append(self._diag(sev, idx, "no closer steps follow (script ends abruptly)"))
+                continue
+
+            nxt = steps[next_idx]
+            if nxt.get("name", "") != "Set Variable":
+                diagnostics.append(self._diag(sev, idx, f"followed by '{nxt.get('name', '?')}', not Set Variable [CreateEventObjectFmErrorsOnly]"))
+                continue
+
+            found_closer = False
+            for calc in nxt.iter("Calculation"):
+                if calc.text and "CreateEventObjectFmErrorsOnly" in calc.text:
+                    found_closer = True
+                    break
+            if not found_closer:
+                diagnostics.append(self._diag(sev, idx, "followed by Set Variable, but the value calc doesn't reference CreateEventObjectFmErrorsOnly"))
+
+        return diagnostics
+
+    def _diag(self, severity, step_idx, reason):
+        return Diagnostic(
+            rule_id=self.rule_id,
+            severity=severity,
+            message=(
+                f"Perform JavaScript in Web Viewer is not wrapped with the "
+                f"canonical Set Error Capture pattern — {reason}. PJSIWV is "
+                f"silent-failure-prone (wrong object name / missing JS "
+                f"function / bad WV state surfaces nothing)."
+            ),
+            line=step_idx + 1,
+            fix_hint=(
+                "Insert Set Error Capture [On] immediately before the PJSIWV "
+                "step. After the PJSIWV, add the canonical 5-step closer: "
+                "Set Variable [$eventObjectFmErrorsOnly ; "
+                "CreateEventObjectFmErrorsOnly] / Set Error Capture [Off] / "
+                "Set Variable [$fmErrorCode ; GetFmErrorCode (...)] / "
+                "If [$fmErrorCode <> 0] / ...build error event + "
+                "Exit Loop If [True] / End If."
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# SL011 — no-double-blank-comments
+# ---------------------------------------------------------------------------
+
+@rule
+class NoDoubleBlankComments(LintRule):
+    """Flag runs of 2+ consecutive blank # (comment) steps.
+
+    The TMPL_NewScript templates ship with double-blank lines as visual
+    "insert your code here" markers between sections. A finished script
+    should clean these up — at most one blank line is needed between
+    sections.
+
+    Team convention 2026-05-15.
+
+    A "blank # (comment)" step is one with no <Text> child element
+    (i.e., a self-closing <Step ... name="# (comment)"/>).
+    """
+
+    rule_id = "SL011"
+    name = "no-double-blank-comments"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        steps = parse_result.steps
+        run_start = None  # index of the first blank in the current run
+        run_len = 0
+        for idx, step in enumerate(steps):
+            if self._is_blank_comment(step):
+                if run_start is None:
+                    run_start = idx
+                run_len += 1
+            else:
+                if run_len >= 2:
+                    diagnostics.append(self._diag(sev, run_start, run_len))
+                run_start = None
+                run_len = 0
+        # Flush trailing run (script ending with consecutive blanks)
+        if run_len >= 2:
+            diagnostics.append(self._diag(sev, run_start, run_len))
+        return diagnostics
+
+    @staticmethod
+    def _is_blank_comment(step) -> bool:
+        if step.get("name", "") != "# (comment)":
+            return False
+        text_el = step.find("Text")
+        if text_el is None:
+            return True
+        # Some converters / scripts emit <Text></Text> for a blank — treat
+        # that as blank too.
+        return not (text_el.text and text_el.text.strip())
+
+    def _diag(self, severity, run_start_idx, run_len):
+        return Diagnostic(
+            rule_id=self.rule_id,
+            severity=severity,
+            message=(
+                f"Run of {run_len} consecutive blank # (comment) steps. "
+                f"The TMPL_NewScript templates ship with double-blank "
+                f"markers to indicate where dev code goes — a finished "
+                f"script should consolidate these to a single blank."
+            ),
+            line=run_start_idx + 1,
+            fix_hint=(
+                f"Delete {run_len - 1} of the consecutive blank # (comment) "
+                "steps so only one blank separator remains between sections."
+            ),
+        )

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -908,3 +908,380 @@ class NoDoubleBlankComments(LintRule):
                 "steps so only one blank separator remains between sections."
             ),
         )
+
+
+# ---------------------------------------------------------------------------
+# SL012 — handle-result-exit-canonical
+# ---------------------------------------------------------------------------
+
+@rule
+class HandleResultExitCanonical(LintRule):
+    """Flag scripts that don't end with the canonical HANDLE RESULT & EXIT
+    block from TMPL_NewScript.
+
+    The template's tail block is highly structured — the cascade shape
+    and Exit Script return value are invariant; only the success-path
+    JSONSetElement is allowed to vary (to return additional values
+    beyond just scriptResult).
+
+    Canonical tail (simplified):
+
+        If [ False ]
+        Else If [ not IsEmpty ( $scriptResultObject ) ]
+          # Already defined.
+        Else If [ IsEmpty ( $errorMessage ) ]
+          Set Variable [ $scriptResult ; OK ]
+          Set Variable [ $scriptResultObject ; JSONSetElement ( ... ) ]
+        Else
+          Set Variable [ $scriptResult ; ERROR ]
+          Set Variable [ $scriptResultMessage ; $errorMessage ]
+          Set Variable [ $scriptResultObject ; JSONSetElement ( ... ) ]
+          Perform Script [ "COM_ScriptResultHandler" ; ... ]
+        End If
+        Exit Script [ $scriptResultObject ]
+
+    Exemption: scripts with NO Loop step are treated as thin wrappers
+    (e.g., INV_OpenNewItemDialog) and are not subject to this rule —
+    they typically Exit Script with Get(ScriptResult) from a sub-script
+    call.
+
+    Surfaced 2026-05-15 — team convention. The HANDLE RESULT block is
+    one of the most distinctive markers of a TMPL_NewScript-conformant
+    script, and divergences here usually mean the caller can't reliably
+    read the result.
+    """
+
+    rule_id = "SL012"
+    name = "handle-result-exit-canonical"
+    category = "sl_fork"
+    default_severity = Severity.ERROR
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        steps = parse_result.steps
+
+        # Exemption: scripts with no Loop are thin wrappers.
+        has_loop = any(s.get("name", "") == "Loop" for s in steps)
+        if not has_loop:
+            return []
+
+        diagnostics = []
+
+        # Find the last non-comment step.
+        last_idx = len(steps) - 1
+        while last_idx >= 0 and steps[last_idx].get("name", "") == "# (comment)":
+            last_idx -= 1
+        if last_idx < 0:
+            return []  # script is all comments — odd but not our concern
+
+        last = steps[last_idx]
+        if last.get("name", "") != "Exit Script":
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    f"Script's final executable step is '{last.get('name', '?')}', "
+                    f"not Exit Script. The canonical TMPL_NewScript tail "
+                    f"ends with Exit Script [ $scriptResultObject ]."
+                ),
+                line=last_idx + 1,
+                fix_hint=(
+                    "Append the canonical HANDLE RESULT & EXIT block: "
+                    "If [False] / Else If [not IsEmpty($scriptResultObject)] / "
+                    "Else If [IsEmpty($errorMessage)] / Else / End If / "
+                    "Exit Script [$scriptResultObject]."
+                ),
+            ))
+            return diagnostics
+
+        # Check Exit Script's calculation is $scriptResultObject.
+        exit_calc = ""
+        for calc in last.iter("Calculation"):
+            if calc.text:
+                exit_calc = calc.text.strip()
+                break
+        if exit_calc != "$scriptResultObject":
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    f"Exit Script returns {exit_calc or '(empty)'}, not "
+                    f"$scriptResultObject. The canonical TMPL_NewScript "
+                    f"tail returns the structured result object so callers "
+                    f"can read scriptResult / scriptResultMessage / "
+                    f"eventObject keys."
+                ),
+                line=last_idx + 1,
+                fix_hint=(
+                    "Change Exit Script's calculation to $scriptResultObject. "
+                    "The preceding HANDLE RESULT block should populate that "
+                    "variable for both success and error paths."
+                ),
+            ))
+
+        # Walk backwards to find the End If that should close the cascade.
+        prev_idx = last_idx - 1
+        while prev_idx >= 0 and steps[prev_idx].get("name", "") == "# (comment)":
+            prev_idx -= 1
+        if prev_idx < 0 or steps[prev_idx].get("name", "") != "End If":
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "Exit Script is not immediately preceded by End If. "
+                    "The canonical HANDLE RESULT cascade closes with End If "
+                    "right before Exit Script."
+                ),
+                line=last_idx + 1,
+                fix_hint="Wrap the result-building logic in an If [False] / Else If / Else / End If cascade before Exit Script.",
+            ))
+            return diagnostics
+
+        # Walk backwards through balanced If/End If pairs to find the
+        # matching If (or Else If at depth 0 — but we want the outer If).
+        depth = 1
+        cascade_open_idx = -1
+        i = prev_idx - 1
+        while i >= 0:
+            name = steps[i].get("name", "")
+            if name == "End If":
+                depth += 1
+            elif name == "If":
+                depth -= 1
+                if depth == 0:
+                    cascade_open_idx = i
+                    break
+            i -= 1
+        if cascade_open_idx < 0:
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message="Could not find the matching If for the cascade-closing End If before Exit Script.",
+                line=prev_idx + 1,
+                fix_hint="Verify the HANDLE RESULT cascade has a properly-balanced If / End If structure.",
+            ))
+            return diagnostics
+
+        # Determine which cascade pattern is in use:
+        #   Pattern A (TMPL_NewScript verbatim): If [False] / Else If [not
+        #     IsEmpty ($scriptResultObject)] / Else If [IsEmpty ($errorMessage)] /
+        #     Else / End If
+        #   Pattern B (ActionRouter variant): If [not IsEmpty
+        #     ($scriptResultObject)] / Else If [IsEmpty ($errorMessage)] /
+        #     Else / End If
+        # Both are functionally equivalent — Pattern B just skips the no-op
+        # If [False] entry. Team ratified 2026-05-15 that both are
+        # acceptable.
+        if_calc = ""
+        for calc in steps[cascade_open_idx].iter("Calculation"):
+            if calc.text:
+                if_calc = calc.text.strip()
+                break
+        if_calc_norm = self._normalize(if_calc)
+
+        pattern_a = if_calc_norm == "False"
+        pattern_b = if_calc_norm == self._normalize("not IsEmpty ( $scriptResultObject )")
+
+        if not (pattern_a or pattern_b):
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    f"HANDLE RESULT cascade's opening If has calculation "
+                    f"'{if_calc}', which doesn't match either canonical "
+                    f"entry: 'False' (Pattern A) or 'not IsEmpty ( "
+                    f"$scriptResultObject )' (Pattern B / ActionRouter)."
+                ),
+                line=cascade_open_idx + 1,
+                fix_hint=(
+                    "Set the cascade-opening If to either 'False' (Pattern A; "
+                    "main branches go on the Else If's that follow) or "
+                    "'not IsEmpty ( $scriptResultObject )' (Pattern B; "
+                    "shorter ActionRouter form)."
+                ),
+            ))
+
+        # Collect Else If conditions to verify the success-path branch.
+        else_if_conditions = []
+        for j in range(cascade_open_idx + 1, prev_idx):
+            if steps[j].get("name", "") == "Else If":
+                for calc in steps[j].iter("Calculation"):
+                    if calc.text:
+                        else_if_conditions.append((j, calc.text.strip()))
+                        break
+
+        # Required: an Else If branch for IsEmpty ( $errorMessage ) — the
+        # success-path branch. Same in both Pattern A and Pattern B.
+        success_branch = self._normalize("IsEmpty ( $errorMessage )")
+        if not any(self._normalize(cond) == success_branch for _, cond in else_if_conditions):
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "HANDLE RESULT cascade is missing the canonical "
+                    "Else If [ IsEmpty ( $errorMessage ) ] branch (the "
+                    "success path)."
+                ),
+                line=cascade_open_idx + 1,
+                fix_hint=(
+                    "Add an Else If [ IsEmpty ( $errorMessage ) ] branch "
+                    "that sets $scriptResult to OK and builds the success "
+                    "$scriptResultObject."
+                ),
+            ))
+
+        # For Pattern A only: also require Else If [ not IsEmpty (
+        # $scriptResultObject ) ]. Pattern B's opening If already serves
+        # this role, so it doesn't need the Else If duplicate.
+        if pattern_a:
+            already_defined = self._normalize("not IsEmpty ( $scriptResultObject )")
+            if not any(self._normalize(cond) == already_defined for _, cond in else_if_conditions):
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        "HANDLE RESULT cascade (Pattern A) is missing the "
+                        "canonical Else If [ not IsEmpty ( $scriptResultObject ) ] "
+                        "branch (the already-defined path)."
+                    ),
+                    line=cascade_open_idx + 1,
+                    fix_hint=(
+                        "Add an Else If [ not IsEmpty ( $scriptResultObject ) ] "
+                        "branch after the If [False] entry — it allows callers "
+                        "to pre-populate the result and short-circuit the rest "
+                        "of the cascade."
+                    ),
+                ))
+
+        # Verify the error (Else) branch includes a Perform Script call to
+        # COM_ScriptResultHandler.
+        has_handler_call = False
+        for j in range(cascade_open_idx, prev_idx):
+            step = steps[j]
+            if step.get("name", "") != "Perform Script":
+                continue
+            script_ref = step.find("Script")
+            if script_ref is not None and "COM_ScriptResultHandler" in (script_ref.get("name", "") or ""):
+                has_handler_call = True
+                break
+        if not has_handler_call:
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "HANDLE RESULT cascade does not call COM_ScriptResultHandler. "
+                    "The canonical tail invokes it on the error path so the "
+                    "centralized result-handler can do dialog / notification "
+                    "/ logging work based on the eventObject."
+                ),
+                line=cascade_open_idx + 1,
+                fix_hint=(
+                    "In the Else (error) branch, after building "
+                    "$scriptResultObject, add: Perform Script [ "
+                    "\"COM_ScriptResultHandler\" ; Parameter: "
+                    "PassSubscriptParameterObject ( $scriptResultObject ) ]."
+                ),
+            ))
+
+        return diagnostics
+
+    @staticmethod
+    def _normalize(s: str) -> str:
+        """Normalize whitespace for comparing calculations — FM is loose
+        about spaces around operators and parens."""
+        return " ".join(s.split())
+
+
+# ---------------------------------------------------------------------------
+# SL013 — no-calc-alignment-padding
+# ---------------------------------------------------------------------------
+
+@rule
+class NoCalcAlignmentPadding(LintRule):
+    """Flag Calculation contents with vertical-alignment padding (runs of
+    2+ consecutive interior spaces).
+
+    Some FM developers format JSONSetElement (and similar multi-line
+    calcs) with extra spaces to vertically align the `;` separators and
+    the `JSONString`/`JSONObject` type tokens, e.g.:
+
+        JSONSetElement ( "{}"
+            ; [ "scriptResult"        ; "ERROR"                                                              ; JSONString ]
+            ; [ "scriptResultMessage" ; $errorMessage                                                        ; JSONString ]
+            ; [ "eventObject"         ; If ( IsEmpty ( $eventObject ) ; CreateEventObjectFm ; $eventObject ) ; JSONObject ]
+        )
+
+    Team convention 2026-05-15 — use single spaces between tokens, no
+    alignment padding:
+
+        JSONSetElement ( "{}"
+            ; [ "scriptResult" ; "ERROR" ; JSONString ]
+            ; [ "scriptResultMessage" ; $errorMessage ; JSONString ]
+            ; [ "eventObject" ; If ( IsEmpty ( $eventObject ) ; CreateEventObjectFm ; $eventObject ) ; JSONObject ]
+        )
+
+    Alignment padding hurts diffs (any change to a long line forces the
+    alignment to re-pad the whole block), reading speed (eyes scan
+    long blank spaces), and the value of the leading tab indentation
+    (the actual code starts well after the visual indent).
+
+    Heuristic: any Calculation whose CDATA text contains a line where —
+    after stripping leading whitespace (tabs/spaces, legitimate
+    indentation) — there are 2+ consecutive interior spaces, is
+    flagged. False positives could occur on multi-space string literals
+    (e.g., \"hello  world\") but those are rare; the diagnostic message
+    explains the false-positive case so devs can recognize it.
+    """
+
+    rule_id = "SL013"
+    name = "no-calc-alignment-padding"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        diagnostics = []
+        for idx, step in enumerate(parse_result.steps):
+            flagged_this_step = False
+            for calc in step.iter("Calculation"):
+                if calc.text is None or not calc.text:
+                    continue
+                # Walk lines, look for 2+ consecutive interior spaces
+                for line in calc.text.split("\n"):
+                    stripped = line.lstrip(" \t")
+                    if "  " in stripped:
+                        diagnostics.append(Diagnostic(
+                            rule_id=self.rule_id,
+                            severity=sev,
+                            message=(
+                                "Calculation contains vertical-alignment "
+                                "padding (2+ consecutive interior spaces). "
+                                "Team convention 2026-05-15 — use single "
+                                "spaces between tokens, no alignment. "
+                                "Alignment padding hurts diffs and "
+                                "readability."
+                            ),
+                            line=idx + 1,
+                            fix_hint=(
+                                "Collapse runs of multiple spaces to single "
+                                "spaces in the calculation. Note: legitimate "
+                                "multi-space string literals (e.g., "
+                                "\"hello  world\") will also trigger — if "
+                                "that's the case, disable this rule on the "
+                                "specific occurrence or treat the warning "
+                                "as informational."
+                            ),
+                        ))
+                        flagged_this_step = True
+                        break
+                if flagged_this_step:
+                    break  # one diagnostic per step is enough
+        return diagnostics

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -1285,3 +1285,282 @@ class NoCalcAlignmentPadding(LintRule):
                 if flagged_this_step:
                     break  # one diagnostic per step is enough
         return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# Helpers for SL014/SL015 (post-Loop section detection)
+# ---------------------------------------------------------------------------
+
+def _find_last_end_loop(steps) -> int:
+    """Return the index of the LAST End Loop step, or -1 if none."""
+    for i in range(len(steps) - 1, -1, -1):
+        if steps[i].get("name", "") == "End Loop":
+            return i
+    return -1
+
+
+def _has_section_marker_after(steps, after_idx: int, *marker_texts: str) -> bool:
+    """Return True if any # (comment) step after `after_idx` has Text
+    that starts with any of the given marker_texts (case-insensitive)."""
+    upper_markers = tuple(m.upper() for m in marker_texts)
+    for j in range(after_idx + 1, len(steps)):
+        if steps[j].get("name", "") != "# (comment)":
+            continue
+        text_el = steps[j].find("Text")
+        if text_el is None or text_el.text is None:
+            continue
+        txt = text_el.text.strip().upper()
+        if any(txt.startswith(m) for m in upper_markers):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# SL014 — missing-cleanup-section
+# ---------------------------------------------------------------------------
+
+@rule
+class MissingCleanupSection(LintRule):
+    """Flag scripts (with a Loop) that don't have a # CLEANUP section
+    header between End Loop and Exit Script.
+
+    The TMPL_NewScript template includes a CLEANUP section after the
+    pseudo-loop for any post-loop teardown work (closing files,
+    releasing locks, restoring window state, etc.). The section header
+    should always exist even if the section body is empty — it's the
+    scannable indicator that the developer considered cleanup and
+    found nothing needed (vs. forgot the section entirely).
+
+    Team convention 2026-05-15.
+    """
+
+    rule_id = "SL014"
+    name = "missing-cleanup-section"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        steps = parse_result.steps
+
+        # Only fires on scripts that have a Loop (excludes thin wrappers).
+        if not any(s.get("name", "") == "Loop" for s in steps):
+            return []
+
+        end_loop_idx = _find_last_end_loop(steps)
+        if end_loop_idx < 0:
+            return []  # has Loop but no matching End Loop — different problem
+
+        if _has_section_marker_after(steps, end_loop_idx, "CLEANUP"):
+            return []
+
+        return [Diagnostic(
+            rule_id=self.rule_id,
+            severity=sev,
+            message=(
+                "Script has a pseudo-loop but no '# CLEANUP' section "
+                "header after End Loop. The TMPL_NewScript template "
+                "always includes the section header (even if the section "
+                "body is empty) so reviewers can confirm cleanup was "
+                "considered."
+            ),
+            line=end_loop_idx + 1,
+            fix_hint=(
+                "Add three # (comment) steps after the END PSEUDO LOOP "
+                "marker: '===' row, 'CLEANUP' label, '---' row. Leave "
+                "the section body empty if no post-loop cleanup is "
+                "needed."
+            ),
+        )]
+
+
+# ---------------------------------------------------------------------------
+# SL015 — missing-display-notification-section
+# ---------------------------------------------------------------------------
+
+@rule
+class MissingDisplayNotificationSection(LintRule):
+    """Flag scripts (with a Loop) that don't have a # DISPLAY NOTIFICATION
+    / ERROR section header between End Loop and Exit Script.
+
+    The TMPL_NewScript template includes a DISPLAY NOTIFICATION /
+    ERROR section after CLEANUP for user-facing dialog / notification
+    output. Two valid populations:
+
+    1. Scripts that DO display dialogs directly: the section contains
+       the canonical If [not IsEmpty ($errorMessage)] dialog-build +
+       If [not IsEmpty ($displayMessageOrNotificationObject)] +
+       Perform Script COM_DisplayMessageDialogOrNotification logic.
+
+    2. Scripts that do NOT display dialogs (sub-scripts, server-side
+       workers, etc.): the section contains a single
+       '# No user notifications in this script.' comment.
+
+    Either way, the section header should exist. Missing the section
+    means the developer didn't consider whether the script needs user
+    feedback.
+
+    Team convention 2026-05-15.
+    """
+
+    rule_id = "SL015"
+    name = "missing-display-notification-section"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        steps = parse_result.steps
+
+        if not any(s.get("name", "") == "Loop" for s in steps):
+            return []
+
+        end_loop_idx = _find_last_end_loop(steps)
+        if end_loop_idx < 0:
+            return []
+
+        # Look for the DISPLAY NOTIFICATION section header. Accept variants:
+        # "DISPLAY NOTIFICATION", "DISPLAY NOTIFICATION / ERROR",
+        # "DISPLAY NOTIFICATIONS / ERROR".
+        if _has_section_marker_after(steps, end_loop_idx, "DISPLAY NOTIFICATION"):
+            return []
+
+        return [Diagnostic(
+            rule_id=self.rule_id,
+            severity=sev,
+            message=(
+                "Script has a pseudo-loop but no '# DISPLAY NOTIFICATION / "
+                "ERROR' section header after End Loop. The TMPL_NewScript "
+                "template always includes this section — either populated "
+                "with the canonical dialog-build logic (for scripts that "
+                "display user feedback directly) or with a single '# No "
+                "user notifications in this script.' comment (for "
+                "sub-scripts / server-side workers)."
+            ),
+            line=end_loop_idx + 1,
+            fix_hint=(
+                "Add three # (comment) steps after the CLEANUP section: "
+                "'===' row, 'DISPLAY NOTIFICATION / ERROR' label, '---' "
+                "row. Then either: (a) the canonical If "
+                "[not IsEmpty ($errorMessage)] build-display-object + "
+                "If [not IsEmpty ($displayMessageOrNotificationObject)] "
+                "Perform Script COM_DisplayMessageDialogOrNotification "
+                "logic, OR (b) a single '# No user notifications in this "
+                "script.' comment."
+            ),
+        )]
+
+
+# ---------------------------------------------------------------------------
+# SL016 — post-loop-section-ordering
+# ---------------------------------------------------------------------------
+
+@rule
+class PostLoopSectionOrdering(LintRule):
+    """Flag post-pseudo-loop sections that appear out of canonical order.
+
+    The TMPL_NewScript canonical order after End Loop is:
+
+        CLEANUP → DISPLAY NOTIFICATION / ERROR → HANDLE RESULT & EXIT
+
+    Why this matters: cleanup work (closing extra windows, returning to
+    the original layout, restoring window state) MUST happen before any
+    user-facing dialog is shown, so the dialog appears with the right
+    visual context. Likewise, the dialog must be shown BEFORE the script
+    exits, since Exit Script tears down the runtime state.
+
+    Team convention 2026-05-15.
+
+    SL014 / SL015 enforce that the section headers exist; this rule
+    enforces they appear in the canonical order. The three rules can
+    fire independently — a script can pass SL014 + SL015 (markers exist)
+    but fail SL016 (order is wrong).
+
+    Sections that are absent from the script don't break ordering — only
+    the ones that ARE present must be in the right order relative to
+    each other.
+    """
+
+    rule_id = "SL016"
+    name = "post-loop-section-ordering"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    # Canonical order of post-loop sections. Each tuple is (display
+    # name, list of accepted Text-startswith prefixes).
+    _CANONICAL_ORDER = (
+        ("CLEANUP", ("CLEANUP",)),
+        ("DISPLAY NOTIFICATION / ERROR", ("DISPLAY NOTIFICATION",)),
+        ("HANDLE RESULT & EXIT", ("HANDLE RESULT",)),
+    )
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        steps = parse_result.steps
+
+        if not any(s.get("name", "") == "Loop" for s in steps):
+            return []  # thin wrapper exempt
+
+        end_loop_idx = _find_last_end_loop(steps)
+        if end_loop_idx < 0:
+            return []
+
+        # Find the FIRST occurrence of each section marker after End Loop.
+        section_idx = {name: None for name, _ in self._CANONICAL_ORDER}
+        for j in range(end_loop_idx + 1, len(steps)):
+            if steps[j].get("name", "") != "# (comment)":
+                continue
+            text_el = steps[j].find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            txt = text_el.text.strip().upper()
+            for name, prefixes in self._CANONICAL_ORDER:
+                if section_idx[name] is not None:
+                    continue  # already recorded
+                if any(txt.startswith(p) for p in prefixes):
+                    section_idx[name] = j
+                    break  # this comment step matched one section; move on
+
+        # Walk the canonical order and verify each present marker's
+        # position is greater than the previous present marker's position.
+        present = [(name, section_idx[name]) for name, _ in self._CANONICAL_ORDER if section_idx[name] is not None]
+        diagnostics = []
+        for i in range(len(present) - 1):
+            cur_name, cur_idx = present[i]
+            nxt_name, nxt_idx = present[i + 1]
+            if cur_idx > nxt_idx:
+                # 'cur' is supposed to come BEFORE 'nxt' but appears AFTER
+                diagnostics.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        f"Post-loop section '{cur_name}' appears AFTER "
+                        f"'{nxt_name}'. Canonical order is "
+                        f"CLEANUP → DISPLAY NOTIFICATION / ERROR → "
+                        f"HANDLE RESULT & EXIT. Cleanup work (closing "
+                        f"extra windows, returning to the original "
+                        f"layout, restoring window state) must happen "
+                        f"BEFORE any user-facing dialog is shown; "
+                        f"dialogs must be shown BEFORE the script exits."
+                    ),
+                    line=cur_idx + 1,
+                    fix_hint=(
+                        f"Move the '{cur_name}' section to before the "
+                        f"'{nxt_name}' section in the script."
+                    ),
+                ))
+                # One diagnostic per inversion is enough — keep going
+                # to catch additional misorderings.
+        return diagnostics

--- a/agent/fmlint/rules/sl_inventory.py
+++ b/agent/fmlint/rules/sl_inventory.py
@@ -1288,6 +1288,120 @@ class NoCalcAlignmentPadding(LintRule):
 
 
 # ---------------------------------------------------------------------------
+# SL017 — leftover-template-scaffolding
+# ---------------------------------------------------------------------------
+
+@rule
+class LeftoverTemplateScaffolding(LintRule):
+    """Flag scripts that still contain TMPL_NewScript scaffolding markers
+    instructing the developer to delete unused template steps.
+
+    The TMPL_NewScript / TMPL_NewScript - Transactions templates include
+    "DELETE THE BELOW IF NO USER DIALOGS IN THIS SCRIPT" as a literal
+    comment in the DISPLAY NOTIFICATION / ERROR section, followed by a
+    block of disabled scaffolding steps. The marker is an instruction to
+    the developer authoring the script: if the script doesn't display
+    user dialogs, delete the marker AND the disabled steps below it.
+
+    A finished, non-template script that still contains this marker is
+    a finished-script smell — either:
+      (a) the disabled scaffolding below was left in by accident
+          (compliance failure), or
+      (b) the marker itself was left in (style failure).
+
+    The fix is mechanical:
+      - If the script doesn't display user dialogs: replace the entire
+        block (marker + disabled steps) with a single
+        '# No user notifications in this script.' comment.
+      - If the script DOES display dialogs: enable the relevant steps
+        (so they're no longer commented out) and remove the marker.
+
+    The TMPL_NewScript and TMPL_NewScript - Transactions templates
+    themselves are exempt from this rule via the TMPL filename prefix.
+
+    Team convention 2026-05-15 (after rebuilding INV_SupplierPriceDates_
+    SaveAllWorker on TMPL_NewScript - Transactions surfaced the marker
+    as leftover scaffolding).
+    """
+
+    rule_id = "SL017"
+    name = "leftover-template-scaffolding"
+    category = "sl_fork"
+    default_severity = Severity.WARNING
+    formats = {"xml"}
+    tier = 1
+
+    _MARKER_SUBSTRINGS = (
+        "DELETE THE BELOW IF NO USER DIALOGS",
+        "DELETE THE BELOW IF NO USER DIALOG",  # tolerate singular
+    )
+
+    # If the script's PURPOSE comment matches one of these template
+    # signatures, it IS the template itself — exempt.
+    _TEMPLATE_PURPOSE_SIGNATURES = (
+        "development template to use",
+    )
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if not parse_result.ok or not parse_result.steps:
+            return []
+        sev = self.severity(config)
+        steps = parse_result.steps
+
+        # Content-based exemption: the TMPL_NewScript / TMPL_NewScript -
+        # Transactions templates carry a distinct PURPOSE comment that no
+        # finished script reproduces. Scan the first ~8 comment steps for
+        # one of the template signatures; if found, this IS the template
+        # and we skip the rule.
+        for step in steps[:20]:
+            if step.get("name", "") != "# (comment)":
+                continue
+            text_el = step.find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            if any(sig in text_el.text for sig in self._TEMPLATE_PURPOSE_SIGNATURES):
+                return []
+
+        diagnostics = []
+        for i, step in enumerate(steps):
+            if step.get("name", "") != "# (comment)":
+                continue
+            text_el = step.find("Text")
+            if text_el is None or text_el.text is None:
+                continue
+            txt = text_el.text.upper()
+            if not any(m in txt for m in self._MARKER_SUBSTRINGS):
+                continue
+
+            diagnostics.append(Diagnostic(
+                rule_id=self.rule_id,
+                severity=sev,
+                message=(
+                    "Leftover TMPL_NewScript scaffolding marker found: "
+                    "'DELETE THE BELOW IF NO USER DIALOGS IN THIS SCRIPT'. "
+                    "This is an instruction to the developer to remove "
+                    "the disabled scaffolding steps below it (or enable "
+                    "them if the script does display dialogs) and delete "
+                    "the marker itself. A finished script should never "
+                    "contain this marker."
+                ),
+                line=i + 1,
+                fix_hint=(
+                    "If this script doesn't display user dialogs, replace "
+                    "the marker AND the disabled steps below it with a "
+                    "single '# No user notifications in this script.' "
+                    "comment. If it DOES display dialogs, enable the "
+                    "relevant Set Variable / If / Perform Script steps "
+                    "and delete the marker."
+                ),
+            ))
+            # One diagnostic per script — the marker is a single point of fix.
+            break
+
+        return diagnostics
+
+
+# ---------------------------------------------------------------------------
 # Helpers for SL014/SL015 (post-Loop section detection)
 # ---------------------------------------------------------------------------
 

--- a/agent/scripts/fm_xml_to_snippet.py
+++ b/agent/scripts/fm_xml_to_snippet.py
@@ -1515,7 +1515,12 @@ def tx_go_to_related_record(step) -> str:
     option          = 'False'
     match_all       = 'False'
     show_new_window = 'False'
-    restore         = 'True'
+    # Restore defaults to False per FM round-trip 2026-05-15. The
+    # snippet_examples archival file lists True; that's wrong — pasting
+    # a step with Restore=True produces "Show only related records" in HR
+    # even when <Option state="False"/>. Apparently Restore controls a
+    # different facet of the step than the snippet_example comment claims.
+    restore         = 'False'
     layout_dest     = 'CurrentLayout'
     table_id        = '0'
     table_name      = ''
@@ -1523,6 +1528,7 @@ def tx_go_to_related_record(step) -> str:
     layout_name     = ''
     has_layout      = False
     animation       = 'None'
+    has_animation   = False  # only emit <Animation> when source explicitly sets it
 
     p = param_by_type(step, 'Related')
     if p is not None:
@@ -1548,14 +1554,27 @@ def tx_go_to_related_record(step) -> str:
         anim = p.find('Animation')
         if anim is not None:
             # "Cross Dissolve" → "CrossDissolve"
-            animation = anim.get('name', 'None').replace(' ', '')
+            anim_name = anim.get('name', 'None').replace(' ', '')
+            if anim_name != 'None':
+                animation = anim_name
+                has_animation = True
+            # Source <Animation name="None" value="0"/> is FM's "no animation"
+            # marker — omit from output so HR doesn't render an empty animation
+            # parameter. FM round-trip 2026-05-15 confirms.
 
         opts = p.find('Options')
         if opts is not None:
-            # ShowRelated="True" means "navigate to related table" (always on),
-            # NOT the "Show only related records" checkbox → Option state is inverted.
-            show_rel = opts.get('ShowRelated', 'False')
-            option   = 'False' if show_rel == 'True' else 'True'
+            # SaXML <Options> child contains attributes for the flag-style
+            # checkboxes in the step's parameter dialog. Empty
+            # <Options></Options> means no flags are set, in which case ALL
+            # boolean checkboxes default to False per the canonical snippet
+            # shape. TODO 2026-05-15: when a script with one of these flags
+            # checked is round-tripped, capture the actual SaXML attribute
+            # name(s) here. Prior `ShowRelated` + inversion logic was
+            # incorrect — it caused empty <Options> to emit
+            # `<Option state="True"/>` (rendering as "Show only related
+            # records" in HR) and bit the 2026-05-15 audit pass.
+            pass
 
     parts = [
         f'{S}<Step enable="{enable}" id="{sid}" name="Go to Related Record">',
@@ -1569,7 +1588,8 @@ def tx_go_to_related_record(step) -> str:
     ]
     if has_layout:
         parts.append(f'{L1}<Layout id="{layout_id}" name="{escape_attr(layout_name)}"/>')
-    parts.append(f'{L1}<Animation value="{animation}"/>')
+    if has_animation:
+        parts.append(f'{L1}<Animation value="{animation}"/>')
     parts.append(f'{S}</Step>')
     return '\n'.join(parts)
 

--- a/agent/scripts/fm_xml_to_snippet.py
+++ b/agent/scripts/fm_xml_to_snippet.py
@@ -334,6 +334,250 @@ def tx_perform_script(step) -> str:
     return '\n'.join(parts)
 
 
+def tx_perform_script_on_server(step) -> str:
+    """
+    Translate Perform Script on Server.
+
+    Two script-reference modes — both must be preserved:
+    - "By name": <List name="By name"> wraps a <Calculation> giving the target script name
+      (typically Get(ScriptName) for self-recursion). Emits <Calculated><Calculation>...</Calculated>.
+    - "From list": <List name="From list"> contains <DataSourceReference> + <ScriptReference>.
+      Emits <Script id="N" name="..."/> (and optional FileReference).
+
+    Plus the parameter Calculation (wrapped in <Parameter><Parameter>... in SaXML, emitted
+    as a top-level <Calculation> in fmxmlsnippet) and the Wait for completion boolean.
+
+    The catalog-driven generic translator strips the script reference and parameter calc
+    silently — this is a project-critical step for PSOS self-recursion (see
+    docs/patterns/psos-self-recursion.md) so it needs a dedicated handler.
+    """
+    enable, sid = step_attrs(step)
+
+    list_mode = None  # 'By name' or 'From list'
+    script_name_calc = ''
+    script_id = '0'
+    script_name = ''
+    file_ref_id = None
+    file_ref_name = None
+    param_calc = ''
+    has_param_calc = False
+    wait = 'True'
+
+    list_p = param_by_type(step, 'List')
+    if list_p is not None:
+        lst = list_p.find('List')
+        if lst is not None:
+            list_mode = lst.get('name', '')
+            # By name: <Calculation> direct child
+            calc = lst.find('Calculation')
+            if calc is not None:
+                # Reuse the nested-Calculation extractor
+                inner = calc.find('Calculation')
+                if inner is not None:
+                    t = inner.find('Text')
+                    if t is not None:
+                        script_name_calc = t.text or ''
+            # From list: <DataSourceReference> + <ScriptReference>
+            ds = lst.find('DataSourceReference')
+            if ds is not None:
+                file_ref_id = ds.get('id', '0')
+                file_ref_name = ds.get('name', '')
+            sr = lst.find('ScriptReference')
+            if sr is not None:
+                script_id = sr.get('id', '0')
+                script_name = sr.get('name', '')
+
+    param_p = param_by_type(step, 'Parameter')
+    if param_p is not None:
+        inner = param_p.find('Parameter')
+        if inner is not None:
+            # The inner <Parameter> wraps a <Calculation> directly (one fewer
+            # level of nesting than get_calc_text expects).
+            outer_calc = inner.find('Calculation')
+            if outer_calc is not None:
+                has_param_calc = True
+                deeper = outer_calc.find('Calculation')
+                if deeper is not None:
+                    t = deeper.find('Text')
+                    if t is not None:
+                        param_calc = t.text or ''
+
+    bool_p = param_by_type(step, 'Boolean')
+    if bool_p is not None:
+        b = bool_p.find('Boolean')
+        if b is not None:
+            wait = b.get('value', 'True')
+
+    parts = [f'{S}<Step enable="{enable}" id="{sid}" name="Perform Script on Server">']
+    # By name: emit <Calculated> wrapping a Calculation
+    if list_mode == 'By name':
+        parts.append(
+            f'{L1}<Calculated><Calculation>{cdata(script_name_calc)}</Calculation></Calculated>'
+        )
+    parts.append(f'{L1}<WaitForCompletion state="{wait}"/>')
+    if has_param_calc:
+        parts.append(f'{L1}<Calculation>{cdata(param_calc)}</Calculation>')
+    # From list: emit FileReference (if any) + Script
+    if list_mode == 'From list':
+        if file_ref_id is not None:
+            parts.append(
+                f'{L1}<FileReference id="{file_ref_id}" name="{escape_attr(file_ref_name)}">'
+            )
+            parts.append(
+                f'{L2}<!-- TODO: insert UniversalPathList path for file reference "{escape_xml(file_ref_name)}" -->'
+            )
+            parts.append(f'{L1}</FileReference>')
+        parts.append(
+            f'{L1}<Script id="{script_id}" name="{escape_attr(script_name)}"/>'
+        )
+    parts.append(f'{S}</Step>')
+    return '\n'.join(parts)
+
+
+def tx_new_window(step) -> str:
+    """
+    Translate New Window.
+
+    SaXML structure is a single <WindowReference> param containing Style, Name,
+    LayoutReferenceContainer (with Label "original layout" for CurrentLayout, or
+    a nested Layout for SelectedLayout), Bounds (height/width/top/left), and
+    Options (Close/Minimize/Maximize/Resize/MenuBar/Toolbar/DimParentWindow +
+    numeric Styles bitmask).
+
+    The catalog-driven generic translator strips all of this silently — every
+    transactional workflow in this codebase relies on a properly-configured
+    New Window for the $windowNameForTransaction isolation-window pattern, so
+    this needs a dedicated handler. See docs/patterns/fm-fmxmlsnippet-gotchas.md
+    section "Go to Layout requires LayoutDestination" for the related enum
+    discussion — New Window uses the same LayoutDestination enum.
+    """
+    enable, sid = step_attrs(step)
+
+    style = 'Document'
+    name_calc = ''
+    layout_dest = 'CurrentLayout'
+    layout_id = None
+    layout_name = ''
+    height_calc = ''
+    width_calc = ''
+    top_calc = ''
+    left_calc = ''
+    # Default options (FM's New Window defaults)
+    opt = {
+        'Close': 'Yes',
+        'Minimize': 'Yes',
+        'Maximize': 'Yes',
+        'Resize': 'Yes',
+        'MenuBar': 'Yes',
+        'Toolbars': 'No',
+        'DimParentWindow': 'No',
+    }
+    styles_bitmask = '1074202114'  # default Document-style bitmask
+
+    wr_p = param_by_type(step, 'WindowReference')
+    if wr_p is not None:
+        wr = wr_p.find('WindowReference')
+        if wr is not None:
+            # Style
+            st_el = wr.find('Style')
+            if st_el is not None:
+                style = st_el.get('name', 'Document')
+            # Name calculation
+            name_el = wr.find('Name')
+            if name_el is not None:
+                name_calc = get_calc_text(name_el)
+            # LayoutReferenceContainer
+            lrc = wr.find('LayoutReferenceContainer')
+            if lrc is not None:
+                label = lrc.find('Label')
+                label_txt = label.text if label is not None else ''
+                # SaXML uses "original layout" Label for the CurrentLayout (HR
+                # default) enum; a nested <Layout> indicates SelectedLayout.
+                nested_layout = lrc.find('Layout')
+                if nested_layout is not None:
+                    layout_dest = 'SelectedLayout'
+                    layout_id = nested_layout.get('id', '0')
+                    layout_name = nested_layout.get('name', '')
+                elif label_txt and 'original' in label_txt.lower():
+                    layout_dest = 'CurrentLayout'
+                # else: keep default CurrentLayout
+            # Bounds
+            bounds = wr.find('Bounds')
+            if bounds is not None:
+                for tag, target in (('height', 'height_calc'),
+                                    ('width', 'width_calc'),
+                                    ('top', 'top_calc'),
+                                    ('left', 'left_calc')):
+                    el = bounds.find(tag)
+                    if el is not None:
+                        val = get_calc_text(el)
+                        if target == 'height_calc':
+                            height_calc = val
+                        elif target == 'width_calc':
+                            width_calc = val
+                        elif target == 'top_calc':
+                            top_calc = val
+                        elif target == 'left_calc':
+                            left_calc = val
+            # Options
+            options = wr.find('Options')
+            if options is not None:
+                styles_bitmask = options.get('value', styles_bitmask)
+                # SaXML uses tag text "True"/"False"; fmxmlsnippet wants Yes/No.
+                tag_to_attr = [
+                    ('Close', 'Close'),
+                    ('Minimize', 'Minimize'),
+                    ('Maximize', 'Maximize'),
+                    ('Resize', 'Resize'),
+                    ('MenuBar', 'MenuBar'),
+                    ('Toolbar', 'Toolbars'),         # note SaXML "Toolbar" → fmxmlsnippet "Toolbars"
+                    ('DimParentWindow', 'DimParentWindow'),
+                ]
+                for sa_tag, attr in tag_to_attr:
+                    el = options.find(sa_tag)
+                    if el is not None and el.text:
+                        opt[attr] = 'Yes' if el.text.strip().lower() == 'true' else 'No'
+
+    parts = [f'{S}<Step enable="{enable}" id="{sid}" name="New Window">']
+    parts.append(f'{L1}<LayoutDestination value="{layout_dest}"/>')
+    # Name (always emit — empty calc is fine if no name supplied)
+    parts.append(f'{L1}<Name>')
+    parts.append(f'{L2}<Calculation>{cdata(name_calc)}</Calculation>')
+    parts.append(f'{L1}</Name>')
+    # Height / Width — emit when present
+    if height_calc or width_calc:
+        parts.append(f'{L1}<Height>')
+        parts.append(f'{L2}<Calculation>{cdata(height_calc)}</Calculation>')
+        parts.append(f'{L1}</Height>')
+        parts.append(f'{L1}<Width>')
+        parts.append(f'{L2}<Calculation>{cdata(width_calc)}</Calculation>')
+        parts.append(f'{L1}</Width>')
+    # Top / Left — emit only if non-empty (rare)
+    if top_calc:
+        parts.append(f'{L1}<DistanceFromTop>')
+        parts.append(f'{L2}<Calculation>{cdata(top_calc)}</Calculation>')
+        parts.append(f'{L1}</DistanceFromTop>')
+    if left_calc:
+        parts.append(f'{L1}<DistanceFromLeft>')
+        parts.append(f'{L2}<Calculation>{cdata(left_calc)}</Calculation>')
+        parts.append(f'{L1}</DistanceFromLeft>')
+    # NewWndStyles
+    parts.append(
+        f'{L1}<NewWndStyles DimParentWindow="{opt["DimParentWindow"]}" '
+        f'Toolbars="{opt["Toolbars"]}" MenuBar="{opt["MenuBar"]}" '
+        f'Style="{style}" Close="{opt["Close"]}" Minimize="{opt["Minimize"]}" '
+        f'Maximize="{opt["Maximize"]}" Resize="{opt["Resize"]}" '
+        f'Styles="{styles_bitmask}"/>'
+    )
+    # Layout element only for SelectedLayout per the 2026-05-14 gotcha note
+    if layout_dest == 'SelectedLayout' and layout_id is not None:
+        parts.append(
+            f'{L1}<Layout id="{layout_id}" name="{escape_attr(layout_name)}"/>'
+        )
+    parts.append(f'{S}</Step>')
+    return '\n'.join(parts)
+
+
 def tx_show_custom_dialog(step) -> str:
     enable, sid = step_attrs(step)
     title_calc = ''
@@ -1758,6 +2002,8 @@ TRANSLATORS = {
     'Exit Script':             tx_exit_script,
     'Set Variable':            tx_set_variable,
     'Perform Script':          tx_perform_script,
+    'Perform Script on Server': tx_perform_script_on_server,
+    'New Window':              tx_new_window,
     'Show Custom Dialog':      tx_show_custom_dialog,
     'Set Field':               tx_set_field,
     'Commit Records/Requests': tx_commit,

--- a/agent/scripts/rebuild_refresh_payload.py
+++ b/agent/scripts/rebuild_refresh_payload.py
@@ -1,0 +1,650 @@
+#!/usr/bin/env python3
+"""Rebuild a RefreshPayload-style script onto TMPL_NewScript shape.
+
+A RefreshPayload is the canonical "build a JSON payload from FM data
+and push it to a web viewer" pattern used by the SL Inventory module's
+dialog scripts (INV_NewItem_RefreshPayload, INV_StandardCost_RefreshPayload,
+INV_PackagingCost_RefreshPayload, INV_SupplierPriceDates_RefreshPayload).
+These scripts typically:
+  - Read a launch parameter from $$INV_*_LaunchParam (or run unparameterized)
+  - Issue ExecuteSQLe queries against type/lookup tables
+  - Assemble a JSON payload via JSONSetElement
+  - Call Perform JavaScript in Web Viewer to push the payload to JS
+
+This tool restructures a freshly-converted RefreshPayload (from
+fm_xml_to_snippet.py) onto the canonical TMPL_NewScript skeleton:
+
+  1. Strip the disabled <Insert Text $README> doc-block (banned by team
+     convention 2026-05-13; SL003 enforces).
+  2. Remove top-level Allow User Abort + Set Error Capture steps
+     (template uses no top-level globals; SL006 enforces).
+  3. Inject a Modified history entry into the existing # HISTORY block.
+  4. Insert BEGIN PSEUDO LOOP marker comments before the outer Loop
+     (SL005 enforces).
+  5. Insert InitializeScriptParameterObject + JSON-validity guard at
+     the top of the pseudo-loop body.
+  6. Wrap each Perform JavaScript in Web Viewer call with the canonical
+     Set Error Capture / CreateEventObjectFmErrorsOnly wrapper (SL010
+     enforces).
+  7. Insert END PSEUDO LOOP marker comments after End Loop (SL005).
+  8. Append CLEANUP, DISPLAY NOTIFICATION / ERROR, and HANDLE RESULT &
+     EXIT sections (SL014, SL015, SL012 enforce).
+  9. Collapse adjacent blank # (comment) steps (SL011).
+  10. Collapse vertical-alignment padding inside Calculation CDATA
+      (SL013).
+
+After this tool runs, the rebuilt script should be lint-clean against
+all SL fork rules. Verify with `python3 -m agent.fmlint <output.xml>`.
+
+Assumptions about input:
+  - File is already converted to fmxmlsnippet (use fm_xml_to_snippet.py
+    first if you have SaXML).
+  - Script has an existing # HISTORY block, OR you've pre-patched one
+    in (this tool's _inject_history function expects the block to exist;
+    it doesn't synthesize one).
+  - Script has at least one Loop step (the outer pseudo-loop).
+  - If the script has Perform JavaScript in Web Viewer steps, each
+    needs its own error message (passed as --error-message; repeat for
+    multiple).
+
+Not in scope:
+  - Transactional workflows (Open/Commit/Revert Transaction) — different
+    shape; use TMPL_NewScript - Transactions as a manual reference.
+  - ActionRouter scripts — use Pattern B HANDLE RESULT (different
+    cascade entry); handle separately.
+  - Scripts without an existing # # PURPOSE / # # HISTORY header —
+    normalize the header manually before running this tool.
+
+Each step writes to disk on success, so partial progress survives if a
+later step throws.
+
+Usage (CLI):
+
+    python3 agent/scripts/rebuild_refresh_payload.py \\
+        agent/sandbox/INV_Whatever_RefreshPayload.xml \\
+        --history-description "Rebuilt on TMPL_NewScript..." \\
+        --init-param-note "INIT PARAM (template convention; this script reads \\$\\$INV_Whatever_LaunchParam instead)" \\
+        --error-message "Could not push Whatever payload to the web viewer" \\
+        [--error-message "Could not push fallback payload"]
+
+Usage (Python API):
+
+    from rebuild_refresh_payload import rebuild
+    rebuild(
+        file_path="agent/sandbox/INV_Whatever_RefreshPayload.xml",
+        desc="Rebuilt on TMPL_NewScript...",
+        init_param_note="INIT PARAM (template convention; ...)",
+        error_messages=["Could not push Whatever payload to the web viewer"],
+    )
+
+Multiple --error-message flags must match the number of PJSIWV steps
+in the script (one error message per call, in source order).
+"""
+
+import argparse
+import re
+import sys
+from datetime import date
+from pathlib import Path
+
+# Date the rebuild ran (used in the injected history entry). Defaults
+# to today; override via CLI --date or by setting the module-level
+# constant before calling rebuild() programmatically.
+DATE = date.today().isoformat()
+AUTHOR = "Special-Lite Developer / Claude"
+
+
+def _strip_readme(content: str) -> str:
+    readme_re = re.compile(
+        r'  <Step enable="False" id="61" name="Insert Text">.*?</Step>\s*\n',
+        re.DOTALL,
+    )
+    return readme_re.sub('', content, count=1)
+
+
+def _remove_top_globals(content: str) -> str:
+    top_global = (
+        '  <Step enable="True" id="89" name="# (comment)"/>\n'
+        '  <Step enable="True" id="85" name="Allow User Abort">\n'
+        '    <Set state="False"/>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="86" name="Set Error Capture">\n'
+        '    <Set state="False"/>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    )
+    return content.replace(top_global, '  <Step enable="True" id="89" name="# (comment)"/>\n', 1)
+
+
+def _inject_history(content: str, desc: str) -> str:
+    entry = (
+        f'  <Step enable="True" id="89" name="# (comment)">\n'
+        f'    <Text>Modified: {DATE} by {AUTHOR} — {desc}</Text>\n'
+        f'  </Step>\n'
+    )
+
+    # Anchor 1: blank # (comment) before "# TODO " header
+    anchor1 = re.compile(
+        r'(\s*<Step enable="True" id="89" name="# \(comment\)"/>\s*\n'
+        r'\s*<Step enable="True" id="89" name="# \(comment\)">\s*\n'
+        r'\s*<Text># TODO )',
+        re.MULTILINE,
+    )
+    m = anchor1.search(content)
+    if m:
+        return content[:m.start(1)] + entry + m.group(1) + content[m.end(1):]
+
+    # Anchor 2: Created/Modified text step followed by blank # (comment)
+    anchor2 = re.compile(
+        r'(<Step enable="True" id="89" name="# \(comment\)">\s*\n'
+        r'\s*<Text>(?:Created|Modified):[^<]*</Text>\s*\n'
+        r'\s*</Step>\s*\n)'
+        r'(\s*<Step enable="True" id="89" name="# \(comment\)"/>)',
+        re.MULTILINE,
+    )
+    matches = list(anchor2.finditer(content))
+    if matches:
+        last = matches[-1]
+        return content[:last.end(1)] + entry + content[last.end(1):]
+
+    raise ValueError("Could not find HISTORY anchor")
+
+
+def _insert_begin_loop_and_init(content: str, init_param_note: str) -> str:
+    loop_step = (
+        '  <Step enable="True" id="71" name="Loop">\n'
+        '    <Restore state="False"/>\n'
+        '    <FlushType value="Always"/>\n'
+        '  </Step>\n'
+    )
+    loop_replacement = (
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        '    <Text>=======================================================================================</Text>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        '    <Text>BEGIN PSEUDO LOOP</Text>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        '    <Text>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</Text>\n'
+        '  </Step>\n'
+        + loop_step +
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        '    <Text>=======================================================================================</Text>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        f'    <Text>{init_param_note}</Text>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="89" name="# (comment)">\n'
+        '    <Text>---------------------------------------------------------------------------------------</Text>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="141" name="Set Variable">\n'
+        '    <Value>\n'
+        '      <Calculation><![CDATA[InitializeScriptParameterObject]]></Calculation>\n'
+        '    </Value>\n'
+        '    <Repetition>\n'
+        '      <Calculation><![CDATA[1]]></Calculation>\n'
+        '    </Repetition>\n'
+        '    <Name>$scriptParameterObject</Name>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="68" name="If">\n'
+        '    <Restore state="False"/>\n'
+        '    <Calculation><![CDATA[not JSONIsValid ( $scriptParameterObject )]]></Calculation>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="141" name="Set Variable">\n'
+        '    <Value>\n'
+        '      <Calculation><![CDATA[CreateEventObject ( 2 ; %EVENT_TYPE_CODE_SL_CUSTOM_ERROR ; "{}" ; "{}" )]]></Calculation>\n'
+        '    </Value>\n'
+        '    <Repetition>\n'
+        '      <Calculation><![CDATA[1]]></Calculation>\n'
+        '    </Repetition>\n'
+        '    <Name>$eventObject</Name>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="141" name="Set Variable">\n'
+        '    <Value>\n'
+        '      <Calculation><![CDATA[GetErrorMessage ( $eventObject )]]></Calculation>\n'
+        '    </Value>\n'
+        '    <Repetition>\n'
+        '      <Calculation><![CDATA[1]]></Calculation>\n'
+        '    </Repetition>\n'
+        '    <Name>$errorMessage</Name>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="72" name="Exit Loop If">\n'
+        '    <Calculation><![CDATA[True]]></Calculation>\n'
+        '  </Step>\n'
+        '  <Step enable="True" id="70" name="End If"/>\n'
+        '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    )
+    return content.replace(loop_step, loop_replacement, 1)
+
+
+def _wrap_pjsiwv_calls(content: str, error_messages: list) -> str:
+    pjsiwv_block = (
+        '  <Step enable="True" id="175" name="Perform JavaScript in Web Viewer">\n'
+        '    <ObjectName>\n'
+        '      <Calculation><![CDATA["WV_CommonDialog"]]></Calculation>\n'
+        '    </ObjectName>\n'
+        '    <FunctionName>\n'
+        '      <Calculation><![CDATA["receivePayload"]]></Calculation>\n'
+        '    </FunctionName>\n'
+        '    <Parameters Count="1">\n'
+        '      <P>\n'
+        '        <Calculation><![CDATA[$payload]]></Calculation>\n'
+        '      </P>\n'
+        '    </Parameters>\n'
+        '  </Step>\n'
+    )
+
+    def wrap(error_msg: str) -> str:
+        return (
+            '  <Step enable="True" id="86" name="Set Error Capture">\n'
+            '    <Set state="True"/>\n'
+            '  </Step>\n'
+            + pjsiwv_block +
+            '  <Step enable="True" id="141" name="Set Variable">\n'
+            '    <Value>\n'
+            '      <Calculation><![CDATA[CreateEventObjectFmErrorsOnly]]></Calculation>\n'
+            '    </Value>\n'
+            '    <Repetition>\n'
+            '      <Calculation><![CDATA[1]]></Calculation>\n'
+            '    </Repetition>\n'
+            '    <Name>$eventObjectFmErrorsOnly</Name>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="86" name="Set Error Capture">\n'
+            '    <Set state="False"/>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="141" name="Set Variable">\n'
+            '    <Value>\n'
+            '      <Calculation><![CDATA[GetFmErrorCode ( $eventObjectFmErrorsOnly )]]></Calculation>\n'
+            '    </Value>\n'
+            '    <Repetition>\n'
+            '      <Calculation><![CDATA[1]]></Calculation>\n'
+            '    </Repetition>\n'
+            '    <Name>$fmErrorCode</Name>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="68" name="If">\n'
+            '    <Restore state="False"/>\n'
+            '    <Calculation><![CDATA[$fmErrorCode <> 0]]></Calculation>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="141" name="Set Variable">\n'
+            '    <Value>\n'
+            '      <Calculation><![CDATA[CreateEventObjectMergeFmErrors ( $eventObjectFmErrorsOnly )]]></Calculation>\n'
+            '    </Value>\n'
+            '    <Repetition>\n'
+            '      <Calculation><![CDATA[1]]></Calculation>\n'
+            '    </Repetition>\n'
+            '    <Name>$eventObject</Name>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="141" name="Set Variable">\n'
+            f'    <Value>\n'
+            f'      <Calculation><![CDATA["{error_msg}: " & GetErrorMessage ( $eventObject )]]></Calculation>\n'
+            '    </Value>\n'
+            '    <Repetition>\n'
+            '      <Calculation><![CDATA[1]]></Calculation>\n'
+            '    </Repetition>\n'
+            '    <Name>$errorMessage</Name>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="72" name="Exit Loop If">\n'
+            '    <Calculation><![CDATA[True]]></Calculation>\n'
+            '  </Step>\n'
+            '  <Step enable="True" id="70" name="End If"/>\n'
+        )
+
+    count = content.count(pjsiwv_block)
+    if count != len(error_messages):
+        raise ValueError(f"Expected {len(error_messages)} PJSIWV blocks, found {count}")
+    # IMPORTANT: track the search position. The wrap() output contains the
+    # pjsiwv_block as a substring, so naive find-from-start would re-find
+    # the just-wrapped block on subsequent iterations (wrapping the same
+    # PJSIWV multiple times and leaving later occurrences untouched).
+    # Bit the 2026-05-15 INV_StandardCost_RefreshPayload rebuild.
+    search_pos = 0
+    for msg in error_messages:
+        idx = content.find(pjsiwv_block, search_pos)
+        if idx == -1:
+            raise ValueError(f"PJSIWV block not found from position {search_pos}")
+        wrapped = wrap(msg)
+        content = content[:idx] + wrapped + content[idx + len(pjsiwv_block):]
+        # Skip past the wrap we just inserted so the next find() starts
+        # after the embedded pjsiwv_block.
+        search_pos = idx + len(wrapped)
+    return content
+
+
+# Post-pseudo-loop block: END PSEUDO LOOP marker → CLEANUP section →
+# DISPLAY NOTIFICATION / ERROR section → HANDLE RESULT & EXIT cascade.
+# Always emitted by the rebuild helper; replaces any existing trailing
+# Exit Script step.
+HANDLE_RESULT_BLOCK = (
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>END PSEUDO LOOP</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>=======================================================================================</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>=======================================================================================</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>CLEANUP</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>---------------------------------------------------------------------------------------</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>=======================================================================================</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>DISPLAY NOTIFICATION / ERROR</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>---------------------------------------------------------------------------------------</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>No user notifications in this script.</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>=======================================================================================</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>HANDLE RESULT &amp; EXIT</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>---------------------------------------------------------------------------------------</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="68" name="If">\n'
+    '    <Restore state="False"/>\n'
+    '    <Calculation><![CDATA[False]]></Calculation>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="161" name="Else If">\n'
+    '    <Calculation><![CDATA[not IsEmpty ( $scriptResultObject )]]></Calculation>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="89" name="# (comment)">\n'
+    '    <Text>Already defined. Just return and exit.</Text>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="161" name="Else If">\n'
+    '    <Calculation><![CDATA[IsEmpty ( $errorMessage )]]></Calculation>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="141" name="Set Variable">\n'
+    '    <Value>\n'
+    '      <Calculation><![CDATA[OK]]></Calculation>\n'
+    '    </Value>\n'
+    '    <Repetition>\n'
+    '      <Calculation><![CDATA[1]]></Calculation>\n'
+    '    </Repetition>\n'
+    '    <Name>$scriptResult</Name>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="141" name="Set Variable">\n'
+    '    <Value>\n'
+    '      <Calculation><![CDATA[JSONSetElement ( "{}" ; [ "scriptResult" ; $scriptResult ; JSONString ] )]]></Calculation>\n'
+    '    </Value>\n'
+    '    <Repetition>\n'
+    '      <Calculation><![CDATA[1]]></Calculation>\n'
+    '    </Repetition>\n'
+    '    <Name>$scriptResultObject</Name>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="69" name="Else">\n'
+    '    <Restore state="False"/>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="141" name="Set Variable">\n'
+    '    <Value>\n'
+    '      <Calculation><![CDATA[ERROR]]></Calculation>\n'
+    '    </Value>\n'
+    '    <Repetition>\n'
+    '      <Calculation><![CDATA[1]]></Calculation>\n'
+    '    </Repetition>\n'
+    '    <Name>$scriptResult</Name>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="141" name="Set Variable">\n'
+    '    <Value>\n'
+    '      <Calculation><![CDATA[$errorMessage]]></Calculation>\n'
+    '    </Value>\n'
+    '    <Repetition>\n'
+    '      <Calculation><![CDATA[1]]></Calculation>\n'
+    '    </Repetition>\n'
+    '    <Name>$scriptResultMessage</Name>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="141" name="Set Variable">\n'
+    '    <Value>\n'
+    '      <Calculation><![CDATA[JSONSetElement ( "{}"\n'
+    '\t; [ "scriptResult" ; $scriptResult ; JSONString ]\n'
+    '\t; [ "scriptResultMessage" ; $scriptResultMessage ; JSONString ]\n'
+    '\t; [ "eventObject" ; If ( IsEmpty ( $eventObject ) ; CreateEventObjectFm ; $eventObject ) ; JSONObject ]\n'
+    ')]]></Calculation>\n'
+    '    </Value>\n'
+    '    <Repetition>\n'
+    '      <Calculation><![CDATA[1]]></Calculation>\n'
+    '    </Repetition>\n'
+    '    <Name>$scriptResultObject</Name>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="1" name="Perform Script">\n'
+    '    <Calculation><![CDATA[PassSubscriptParameterObject ( $scriptResultObject )]]></Calculation>\n'
+    '    <Script id="0" name="COM_ScriptResultHandler"/>\n'
+    '  </Step>\n'
+    '  <Step enable="True" id="70" name="End If"/>\n'
+    '  <Step enable="True" id="103" name="Exit Script">\n'
+    '    <Calculation><![CDATA[$scriptResultObject]]></Calculation>\n'
+    '  </Step>\n'
+)
+
+
+def _append_end_loop_and_handle_result(content: str) -> str:
+    # Find the LAST End Loop step (the outer pseudo-loop's End Loop).
+    # After it, there may or may not be an existing trailing Exit Script.
+    # Replace from "<End Loop> [optional Exit Script step] </fmxmlsnippet>"
+    # with "<End Loop> + HANDLE RESULT block + </fmxmlsnippet>".
+
+    # Pattern: match End Loop, optionally followed by an Exit Script step,
+    # immediately before the closing </fmxmlsnippet>.
+    tail_re = re.compile(
+        r'(\s*<Step enable="True" id="73" name="End Loop"/>\s*\n)'
+        r'(?:\s*<Step enable="True" id="103" name="Exit Script">.*?</Step>\s*\n)?'
+        r'(</fmxmlsnippet>\s*\n?)$',
+        re.DOTALL,
+    )
+    m = tail_re.search(content)
+    if not m:
+        raise ValueError("Could not find End Loop / </fmxmlsnippet> tail")
+
+    new_tail = m.group(1) + HANDLE_RESULT_BLOCK + m.group(2)
+    return content[:m.start()] + new_tail
+
+
+def _collapse_calc_multispace(content: str) -> str:
+    """Inside each <Calculation> CDATA block, collapse runs of 2+
+    consecutive interior spaces down to a single space (preserving
+    leading whitespace / tabs for indentation).
+
+    Some FM developers add vertical-alignment padding to JSONSetElement
+    arguments and similar calcs — banned by SL013 (team convention
+    2026-05-15). This pass normalizes any pre-existing alignment
+    padding in calcs that the rebuild helper preserves verbatim from
+    source.
+    """
+    def collapse(match):
+        prefix, body, suffix = match.group(1), match.group(2), match.group(3)
+        # Walk lines, collapse 2+ interior spaces but preserve leading
+        # whitespace (tabs/spaces that form line indentation).
+        new_lines = []
+        for line in body.split("\n"):
+            stripped = line.lstrip(" \t")
+            leading = line[: len(line) - len(stripped)]
+            # Collapse 2+ runs of spaces within the stripped portion
+            collapsed = re.sub(r" {2,}", " ", stripped)
+            new_lines.append(leading + collapsed)
+        return prefix + "\n".join(new_lines) + suffix
+
+    cdata_re = re.compile(
+        r"(<Calculation><!\[CDATA\[)(.*?)(\]\]></Calculation>)",
+        re.DOTALL,
+    )
+    return cdata_re.sub(collapse, content)
+
+
+def _collapse_adjacent_blanks(content: str) -> str:
+    """Collapse runs of 2+ consecutive blank # (comment) steps down to a
+    single blank. Section transitions inserted by other rebuild passes
+    can end up adjacent to blanks that were already there, leaving
+    visible double-blanks. SL011 flags those — this pass eliminates
+    them as a final cleanup step.
+    """
+    blank = '  <Step enable="True" id="89" name="# (comment)"/>\n'
+    while blank + blank in content:
+        content = content.replace(blank + blank, blank)
+    return content
+
+
+def rebuild(file_path: str, desc: str, init_param_note: str, error_messages: list):
+    p = Path(file_path)
+    bn = p.name
+    print(f"=== {bn} ===")
+
+    # Step 1
+    content = p.read_text()
+    new = _strip_readme(content)
+    if new != content:
+        content = new
+        p.write_text(content)
+        print("  ✓ $README stripped")
+    else:
+        print("  (no $README block)")
+
+    # Step 2
+    new = _remove_top_globals(content)
+    if new != content:
+        content = new
+        p.write_text(content)
+        print("  ✓ top-level globals removed")
+    else:
+        print("  (no top-level globals)")
+
+    # Step 3
+    content = _inject_history(content, desc)
+    p.write_text(content)
+    print("  ✓ Modified history entry injected")
+
+    # Steps 4-5
+    content = _insert_begin_loop_and_init(content, init_param_note)
+    p.write_text(content)
+    print("  ✓ BEGIN PSEUDO LOOP + Init inserted")
+
+    # Step 6
+    content = _wrap_pjsiwv_calls(content, error_messages)
+    p.write_text(content)
+    print(f"  ✓ {len(error_messages)} PJSIWV block(s) wrapped")
+
+    # Steps 7-8
+    content = _append_end_loop_and_handle_result(content)
+    p.write_text(content)
+    print("  ✓ END PSEUDO LOOP + HANDLE RESULT appended")
+
+    # Step 9: collapse adjacent blanks (SL011 cleanup)
+    new = _collapse_adjacent_blanks(content)
+    if new != content:
+        content = new
+        p.write_text(content)
+        print("  ✓ adjacent blanks collapsed")
+
+    # Step 10: collapse multi-space alignment padding inside calcs (SL013 cleanup)
+    new = _collapse_calc_multispace(content)
+    if new != content:
+        content = new
+        p.write_text(content)
+        print("  ✓ calc alignment padding collapsed")
+
+
+def _cli() -> int:
+    parser = argparse.ArgumentParser(
+        prog="rebuild_refresh_payload.py",
+        description=(
+            "Rebuild a RefreshPayload-style script onto TMPL_NewScript "
+            "shape. Operates in place on an already-converted fmxmlsnippet "
+            "file (use fm_xml_to_snippet.py first if you have SaXML). See "
+            "the module docstring for full details."
+        ),
+        epilog=(
+            "After running, validate the output with "
+            "`python3 -m agent.fmlint <file>` — the rebuilt script should "
+            "be clean against all SL fork rules (SL001–SL015)."
+        ),
+    )
+    parser.add_argument(
+        "file",
+        help=(
+            "Path to the fmxmlsnippet file to rebuild in place. Typically "
+            "agent/sandbox/INV_<Name>_RefreshPayload.xml."
+        ),
+    )
+    parser.add_argument(
+        "-d", "--history-description",
+        required=True,
+        help=(
+            "Text for the Modified history entry that gets injected into "
+            "the script's # # HISTORY block. Describe what was changed and "
+            "why (e.g., 'Rebuilt on TMPL_NewScript. ...')."
+        ),
+    )
+    parser.add_argument(
+        "-n", "--init-param-note",
+        default="INIT PARAM (template convention; this script reads $$<launch_param_global> instead)",
+        help=(
+            "Comment text for the INIT PARAM section header in the "
+            "pseudo-loop body. Use to clarify what global / launch param "
+            "the script reads (since RefreshPayload scripts typically "
+            "ignore the script parameter and read from "
+            "$$INV_<Name>_LaunchParam)."
+        ),
+    )
+    parser.add_argument(
+        "-e", "--error-message",
+        action="append",
+        default=[],
+        metavar="MESSAGE",
+        help=(
+            "Error message for a Perform JavaScript in Web Viewer call. "
+            "Repeat for each PJSIWV step in the script, in source order. "
+            "Used in the error path of the canonical Set Error Capture "
+            "wrapper. Example: 'Could not push payload to the New Item "
+            "web viewer'."
+        ),
+    )
+    parser.add_argument(
+        "--date",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Override the date stamped on the injected history entry (defaults to today).",
+    )
+    parser.add_argument(
+        "--author",
+        default=None,
+        help="Override the author stamped on the injected history entry.",
+    )
+    args = parser.parse_args()
+
+    # Apply optional date / author overrides
+    global DATE, AUTHOR
+    if args.date:
+        DATE = args.date
+    if args.author:
+        AUTHOR = args.author
+
+    try:
+        rebuild(
+            file_path=args.file,
+            desc=args.history_description,
+            init_param_note=args.init_param_note,
+            error_messages=args.error_message,
+        )
+    except (ValueError, AssertionError, FileNotFoundError) as e:
+        print(f"\nERROR: {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/agent/snippet_examples/steps/navigation/Go to Related Record.xml
+++ b/agent/snippet_examples/steps/navigation/Go to Related Record.xml
@@ -4,20 +4,20 @@
     <Option state="False"/>
     <MatchAllRecords state="False"/>
     <ShowInNewWindow state="False"/>
-    <Restore state="True"/>
+    <Restore state="False"/>
     <LayoutDestination value="SelectedLayout"/>
     <NewWndStyles Style="Document" Close="Yes" Minimize="Yes" Maximize="Yes" Resize="Yes" Styles="3606018"/>
     <Table id="0" name=""/>
     <Layout id="0" name=""/>
-    <Animation value="None"/>
   </Step>
 </fmxmlsnippet>
 <!-- Option state: "True" shows only related records (Show only related records). "False" does not filter. -->
 <!-- MatchAllRecords state: "True" matches all records in current found set (Match found set). "False" matches current record only. -->
 <!-- ShowInNewWindow state: "True" shows related records in new window (New window). "False" shows in current window. -->
+<!-- Restore state: NOT surfaced in HR. Canonical default is "False" — verified via FM round-trip 2026-05-15. Emitting "True" causes FM HR to render as if "Show only related records" were checked, even when <Option state="False"/>. Prior version of this snippet incorrectly emitted state="True". -->
 <!-- LayoutDestination value: "CurrentLayout" | "SelectedLayout" | "LayoutNameByCalc" | "LayoutNumberByCalc" | "UseExternalTableLayouts" -->
 <!-- NewWndStyles attributes: Style ("Document" | "Floating" | "Dialog" | "Card"), Close/Minimize/Maximize/Resize ("Yes" | "No"), DimParentWindow/Toolbars/MenuBar ("Yes" | "No"), Styles (numeric bitmask). Only applies when ShowInNewWindow is True. -->
-<!-- Animation value: "SlideFromLeft" | "SlideFromRight" | "SlideFromBottom" | "SlideToLeft" | "SlideToRight" | "SlideToBottom" | "FlipFromLeft" | "FlipFromRight" | "ZoomIn" | "ZoomOut" | "CrossDissolve". FileMaker Go only. -->
+<!-- Animation: OMIT the element entirely for the "None" default. Emitting <Animation value="None"/> produces a stray "External" prefix in HR (verified via FM round-trip 2026-05-15). Include only with a non-None value: "SlideFromLeft" | "SlideFromRight" | "SlideFromBottom" | "SlideToLeft" | "SlideToRight" | "SlideToBottom" | "FlipFromLeft" | "FlipFromRight" | "ZoomIn" | "ZoomOut" | "CrossDissolve". FileMaker Go only. -->
 <!-- Required: Table (source relationship to go to). -->
 <!-- Optional: Layout, Option (Show only related records), MatchAllRecords (Match found set), ShowInNewWindow (New window), Animation (Go only), NewWndStyles, Name/Height/Width/DistanceFromTop/DistanceFromLeft (window params when ShowInNewWindow). -->
 <!-- Goes to current related record(s) in related table. -->


### PR DESCRIPTION
## Summary

- New SL017 rule flags scripts that still contain the TMPL_NewScript scaffolding marker `DELETE THE BELOW IF NO USER DIALOGS IN THIS SCRIPT`
- The marker is a template instruction to the author: delete it (and either keep the disabled scaffolding deleted or enable the relevant steps before deleting the marker). A finished script should never carry it.
- TMPL_NewScript / TMPL_NewScript - Transactions are exempt via a content-based signature check (`"development template to use"` in any of the first 20 comment steps). Path-based exemption isn't an option — rules don't receive a path argument.

## Why now

Surfaced during the 2026-05-15 rebuild of `INV_SupplierPriceDates_SaveAllWorker` (id 1012) onto `TMPL_NewScript - Transactions`. The first pass left the marker plus its four disabled `// Set Variable` / `// If` / `// Perform Script` scaffolding lines in the `DISPLAY NOTIFICATION / ERROR` section. Trevor caught it manually; this rule pays the cost back on every future template-derived script.

## Smoke test results

| Case | Expected | Actual |
|---|---|---|
| `TMPL_NewScript` (id 6) | exempt | ✅ exempt |
| `TMPL_NewScript - Transactions` (id 513) | exempt | ✅ exempt |
| 1012 freshly rebuilt | clean | ✅ clean |
| Synthetic fixture with marker | fires | ✅ fires |
| `INV_ItemNavToTransfer` (id 952) | unknown | ✅ **caught a real leftover** in production code |

The id-952 finding suggests it's worth grepping the wider corpus after this lands and queuing those as follow-up cleanup PRs in sl-inventory.

## Test plan

- [x] Rule loads via `from agent.fmlint.rules import sl_inventory`
- [x] Synthetic fixture with marker → SL017 fires at correct line
- [x] Synthetic fixture without marker → SL017 silent
- [x] Both TMPL files → SL017 silent (signature exemption)
- [x] Freshly rebuilt 1012 → SL017 silent
- [x] Real-world `INV_ItemNavToTransfer` (id 952) → SL017 fires (legitimate finding)
- [ ] Reviewer: confirm "development template to use" is unique enough to template files; no false-negative on a non-template script that happens to mention "template" in its PURPOSE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)