### PR TITLE
Show Custom Dialog InputFields converter + Explode XML hardening

### DIFF
--- a/agent/scripts/fm_xml_to_snippet.py
+++ b/agent/scripts/fm_xml_to_snippet.py
@@ -339,6 +339,9 @@ def tx_show_custom_dialog(step) -> str:
     title_calc = ''
     message_calc = ''
     buttons = []  # list of (label_str, commit_state_str)
+    # input_fields[i] = {'use_password': str, 'kind': 'field'|'variable'|'empty',
+    #                    'table': str, 'id': str, 'name': str, 'var': str, 'label': str}
+    input_fields = {1: None, 2: None, 3: None}
 
     for p in all_params(step):
         ptype = p.get('type', '')
@@ -353,6 +356,40 @@ def tx_show_custom_dialog(step) -> str:
             if b is not None:
                 commit = b.get('value', 'False')
             buttons.append((label, commit))
+        elif ptype in ('Field1', 'Field2', 'Field3'):
+            slot = int(ptype[-1])
+            entry = {
+                'use_password': 'False',
+                'kind': 'empty',
+                'table': '',
+                'id': '0',
+                'name': '',
+                'var': '',
+                'label': '',
+            }
+            # Password flag
+            for b in p.findall('Boolean'):
+                if b.get('type', '') == 'Password':
+                    entry['use_password'] = b.get('value', 'False')
+            # Target (field or variable)
+            for sub in p.findall('Parameter'):
+                if sub.get('type', '') == 'Target':
+                    var_el = sub.find('Variable')
+                    if var_el is not None:
+                        entry['kind'] = 'variable'
+                        entry['var'] = var_el.get('value', '')
+                        continue
+                    fr = sub.find('FieldReference')
+                    if fr is not None:
+                        entry['kind'] = 'field'
+                        entry['id'] = fr.get('id', '0')
+                        entry['name'] = fr.get('name', '')
+                        tor = fr.find('TableOccurrenceReference')
+                        if tor is not None:
+                            entry['table'] = tor.get('name', '')
+                elif sub.get('type', '') == 'Label':
+                    entry['label'] = get_calc_text(sub)
+            input_fields[slot] = entry
 
     parts = [
         f'{S}<Step enable="{enable}" id="{sid}" name="Show Custom Dialog">',
@@ -375,7 +412,42 @@ def tx_show_custom_dialog(step) -> str:
             ]
         else:
             parts.append(f'{L2}<Button CommitState="{commit}"/>')
-    parts += [f'{L1}</Buttons>', f'{S}</Step>']
+    parts.append(f'{L1}</Buttons>')
+
+    # Emit InputFields only when at least one slot is populated. FM's
+    # canonical snippet shows three slots even when only one is used, so
+    # mirror that — empty slots become <Field table="" id="0" name=""/>.
+    if any(f is not None for f in input_fields.values()):
+        parts.append(f'{L1}<InputFields>')
+        for slot in (1, 2, 3):
+            f = input_fields[slot]
+            if f is None:
+                parts += [
+                    f'{L2}<InputField UsePasswordCharacter="False">',
+                    f'{L3}<Field table="" id="0" name=""/>',
+                    f'{L2}</InputField>',
+                ]
+                continue
+            parts.append(f'{L2}<InputField UsePasswordCharacter="{f["use_password"]}">')
+            if f['kind'] == 'variable':
+                parts.append(f'{L3}<Field>{escape_attr(f["var"])}</Field>')
+            elif f['kind'] == 'field':
+                parts.append(
+                    f'{L3}<Field table="{escape_attr(f["table"])}" id="{f["id"]}"'
+                    f' name="{escape_attr(f["name"])}"/>'
+                )
+            else:
+                parts.append(f'{L3}<Field table="" id="0" name=""/>')
+            if f['label']:
+                parts += [
+                    f'{L3}<Label>',
+                    f'{L1}{L3}<Calculation>{cdata(f["label"])}</Calculation>',
+                    f'{L3}</Label>',
+                ]
+            parts.append(f'{L2}</InputField>')
+        parts.append(f'{L1}</InputFields>')
+
+    parts.append(f'{S}</Step>')
     return '\n'.join(parts)
 
 

--- a/filemaker/agentic-fm.xml
+++ b/filemaker/agentic-fm.xml
@@ -271,20 +271,69 @@
       <Step enable="True" id="103" name="Exit Script"/>
       <Step enable="True" id="70" name="End If"/>
       <Step enable="True" id="89" name="# (comment)"/>
+      <Step enable="True" id="89" name="# (comment)">
+        <Text>Ensure ~/Desktop/agentic-fm/ exists for the XML export.</Text>
+      </Step>
+      <Step enable="True" id="67" name="Perform AppleScript">
+        <ContentType value="Text"/>
+        <Text>do shell script "mkdir -p ~/Desktop/agentic-fm"</Text>
+      </Step>
       <Step enable="True" id="141" name="Set Variable">
         <Value>
-          <Calculation><![CDATA[Get ( DesktopPath ) & Get ( FileName ) & ".xml"]]></Calculation>
+          <Calculation><![CDATA[Get ( DesktopPath ) & "agentic-fm/" & Get ( FileName ) & ".xml"]]></Calculation>
         </Value>
         <Repetition>
           <Calculation><![CDATA[1]]></Calculation>
         </Repetition>
         <Name>$output</Name>
       </Step>
+      <Step enable="True" id="89" name="# (comment)">
+        <Text>Pre-clean: Save a Copy as XML won't overwrite an existing file.</Text>
+      </Step>
+      <Step enable="True" id="86" name="Set Error Capture">
+        <Set state="True"/>
+      </Step>
+      <Step enable="True" id="197" name="Delete File">
+        <UniversalPathList>$output</UniversalPathList>
+      </Step>
+      <Step enable="True" id="86" name="Set Error Capture">
+        <Set state="False"/>
+      </Step>
       <Step enable="True" id="3" name="Save a Copy as XML">
         <Option state="False"/>
         <UniversalPathList>$output</UniversalPathList>
         <Calculation><![CDATA[Get ( WindowName )]]></Calculation>
       </Step>
+      <Step enable="True" id="141" name="Set Variable">
+        <Value>
+          <Calculation><![CDATA[Get ( LastError )]]></Calculation>
+        </Value>
+        <Repetition>
+          <Calculation><![CDATA[1]]></Calculation>
+        </Repetition>
+        <Name>$saveError</Name>
+      </Step>
+      <Step enable="True" id="68" name="If">
+        <Restore state="False"/>
+        <Calculation><![CDATA[$saveError ≠ 0]]></Calculation>
+      </Step>
+      <Step enable="True" id="87" name="Show Custom Dialog">
+        <Title>
+          <Calculation><![CDATA["Save as XML failed"]]></Calculation>
+        </Title>
+        <Message>
+          <Calculation><![CDATA["FileMaker could not write the XML export to:¶¶" & $output & "¶¶Error " & $saveError & ": " & Get ( LastErrorDetail ) & "¶¶Common causes: stale file at the target path, missing Files-and-Folders permission for FileMaker on Desktop, or read-only volume."]]></Calculation>
+        </Message>
+        <Buttons>
+          <Button CommitState="True">
+            <Calculation><![CDATA["OK"]]></Calculation>
+          </Button>
+          <Button CommitState="False"/>
+          <Button CommitState="False"/>
+        </Buttons>
+      </Step>
+      <Step enable="True" id="103" name="Exit Script"/>
+      <Step enable="True" id="70" name="End If"/>
       <Step enable="True" id="89" name="# (comment)"/>
       <Step enable="True" id="141" name="Set Variable">
         <Value>


### PR DESCRIPTION
## Summary

Two unrelated fixes that surfaced during the same refactor pass.

### Converter — `fm_xml_to_snippet.py`

`tx_show_custom_dialog` previously emitted only `Title`, `Message`, and `Button*` — it silently dropped any `Field1`/`Field2`/`Field3` parameters. Round-tripping a Show Custom Dialog that prompts for input lost the input fields, so the developer saw a dialog with the message but no input slots.

Now the handler:
- Reads each `<Parameter type="FieldN">` block (1-3)
- Handles both target shapes: `<FieldReference>` (with optional `TableOccurrenceReference`) and `<Variable>`
- Reads the `Password` boolean → `UsePasswordCharacter` attribute
- Reads the optional `Label` calculation
- Emits the FM-canonical `<InputFields>` block with three `<InputField>` entries (empty slots become `<Field table="" id="0" name=""/>`)

Verified by extracting a Show Custom Dialog with two input fields (one field-ref + one password field) from a SaXML export and round-tripping it through the converter — output matches FM's clipboard form exactly.

### Explode XML script — `filemaker/agentic-fm.xml`

Interactive mode previously saved directly to `~/Desktop/<solution>.xml` with no error checking. If FM's `Save a Copy as XML` failed (most commonly because a stale file already existed at the target path — FM won't overwrite), the script kept going and POSTed the path to the companion, which then archived a 0-byte file into `xml_exports/`. The user only saw FM's cryptic "could not be created on this disk" dialog, with no script-level fallback.

Changes:
- **Subfolder**: save to `~/Desktop/agentic-fm/<solution>.xml` instead of cluttering the Desktop.
- **Auto-create folder**: `Perform AppleScript [ do shell script "mkdir -p ~/Desktop/agentic-fm" ]` before the save.
- **Pre-clean**: `Set Error Capture [ On ]` → `Delete File [ $output ]` → `Set Error Capture [ Off ]` removes any stale 0-byte file from a prior failed run.
- **Error reporting**: after `Save a Copy as XML`, capture `Get(LastError)` and surface a descriptive dialog (path + error code + `LastErrorDetail` + common-cause hints) before exiting. No more silent failure path.

## Test plan

- [ ] Convert a SaXML script containing `<Parameter type="Field1">` with a `FieldReference` target. Verify the resulting fmxmlsnippet has an `<InputFields>` block with three `<InputField>` entries — populated slot has the right `table`/`id`/`name`, empty slots match FM's `<Field table="" id="0" name=""/>` form.
- [ ] Convert a SaXML script with a `<Parameter type="Field1">` whose target is a `<Variable value="$x"/>`. Verify the output uses `<Field>$x</Field>` (variable form).
- [ ] Re-install the updated **agentic-fm** script folder (paste `filemaker/agentic-fm.xml`). Delete `~/Desktop/agentic-fm/` if present.
- [ ] Run **Explode XML** from FileMaker. Verify `~/Desktop/agentic-fm/` is created and the export lands inside.
- [ ] Manually leave a stale `~/Desktop/agentic-fm/<solution>.xml` (e.g. `touch` it as empty). Re-run **Explode XML**. Verify the pre-clean removes the stale file and the save succeeds.
- [ ] To exercise the error path: drop FM's Desktop permission, re-run **Explode XML**, and verify the new dialog surfaces the FM error code + detail instead of FM's bare "could not be created" alert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)