### PR TITLE
Windows clipboard support via clipboard_win.py

### DIFF
--- a/agent/config/automation.json.example
+++ b/agent/config/automation.json.example
@@ -4,6 +4,11 @@
   "auto_save": false,
   "fm_app_name": "FileMaker Pro",
   "companion_url": "http://localhost:8765",
+
+  "_wsl2_note": "The two keys below are only needed on Windows + WSL2. The companion server auto-detects the export path via cmd.exe+wslpath; set export_dir_override only if auto-detection fails.",
+  "repo_path_override": "/home/<you>/agentic-fm",
+  "export_dir_override": "/mnt/c/Users/<you>/Desktop",
+
   "tiers": {
     "1": {
       "description": "Clipboard only — agent writes XML to clipboard, developer pastes with Cmd+V",

--- a/agent/docs/CLIPBOARD.md
+++ b/agent/docs/CLIPBOARD.md
@@ -193,6 +193,51 @@ Note that `pb.clearContents()` is required before writing — without it, stale 
 
 ---
 
+## Windows clipboard (WSL2)
+
+FileMaker Pro on Windows registers the same four-letter class codes as custom Windows clipboard formats, prefixed with `Mac-` following Apple's Carbon cross-platform clipboard convention (used by FileMaker since FM7).
+
+| macOS class | Windows format name |
+|-------------|---------------------|
+| `XMSS`      | `Mac-XMSS`          |
+| `XMSC`      | `Mac-XMSC`          |
+| `XML2`      | `Mac-XML2`          |
+| `XMFD`      | `Mac-XMFD`          |
+| `XMFN`      | `Mac-XMFN`          |
+| `XMTB`      | `Mac-XMTB`          |
+| `XMVL`      | `Mac-XMVL`          |
+| `XMTH`      | `Mac-XMTH`          |
+| `ut16`      | `Mac-ut16`          |
+
+The data payload differs from macOS: FileMaker on Windows prepends a 4-byte little-endian `uint32` length field before the UTF-8 XML, and omits the XML declaration:
+
+```
+[4 bytes LE uint32 = N]  [N bytes UTF-8 XML starting with <fmxmlsnippet>]
+```
+
+On macOS the payload is plain UTF-8 XML with no prefix or length field.
+
+### clipboard_win.py
+
+`agent/scripts/clipboard_win.py` provides the same `read` / `write` / `detect` interface as `clipboard.py` but runs on WSL2. It delegates clipboard operations to `powershell.exe` via a temp `.ps1` file written to the Windows TEMP directory (so `powershell.exe` can read it — WSL2 paths are not directly accessible to Windows executables). The PowerShell script P/Invokes `user32.dll` / `kernel32.dll` to call `RegisterClipboardFormat`, `SetClipboardData`, and `GetClipboardData`.
+
+```bash
+# Write XML to Windows clipboard (class auto-detected)
+python3 agent/scripts/clipboard_win.py write agent/sandbox/myscript.xml
+
+# Read FM objects from Windows clipboard
+python3 agent/scripts/clipboard_win.py read agent/sandbox/output.xml
+
+# List all custom clipboard formats -- run after copying from FM to verify format names
+python3 agent/scripts/clipboard_win.py detect
+```
+
+If FileMaker does not accept the paste, run `detect` after copying a script step from FM Pro to see the exact format name registered on your installation. Pass the observed prefix via `--format-prefix` if it differs from `Mac-`.
+
+The companion server automatically uses `clipboard_win.py` on Linux (WSL2) and `clipboard.py` on macOS — no configuration needed.
+
+---
+
 ## Reference
 
 The approach above is derived from [FmClipTools](https://github.com/DanShockley/FmClipTools) by Daniel A. Shockley and Erik Shagdar, which provides a complete AppleScript library for FileMaker clipboard operations including batch conversion, prettifying, and class detection.

--- a/agent/scripts/clipboard_win.py
+++ b/agent/scripts/clipboard_win.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""
+clipboard_win.py -- Read and write FileMaker fmxmlsnippets via the Windows clipboard from WSL2.
+
+On Windows, FileMaker Pro registers custom clipboard formats using the "Mac-" prefix
+convention from Apple's Carbon cross-platform clipboard era (e.g. "Mac-XMSS" for
+script steps, "Mac-XMSC" for full scripts).
+
+The binary payload format is:
+  [4 bytes] little-endian uint32 = byte-length of the following XML
+  [N bytes] UTF-8 XML starting with <fmxmlsnippet> (no XML declaration)
+
+This differs from macOS where the payload is plain UTF-8 XML with no prefix.
+
+This script runs on WSL2 and delegates clipboard operations to powershell.exe, which
+can call the Windows clipboard API (user32.dll / kernel32.dll) via P/Invoke.  The
+PowerShell script is written to the Windows TEMP directory so that powershell.exe can
+read it (WSL2 filesystem paths are not directly accessible to Windows executables
+without the \\\\wsl.localhost\\ UNC form).
+
+Usage:
+    Write XML file to clipboard (class auto-detected from XML content):
+        python3 agent/scripts/clipboard_win.py write agent/sandbox/myscript.xml
+
+    Write with an explicit FM class override:
+        python3 agent/scripts/clipboard_win.py write agent/sandbox/myscript.xml --class XMSS
+
+    Detect what clipboard formats are present -- copy something in FM first, then run:
+        python3 agent/scripts/clipboard_win.py detect
+
+    Read FM objects from clipboard, output as XML:
+        python3 agent/scripts/clipboard_win.py read [output.xml]
+
+Troubleshooting:
+    If FileMaker does not accept the paste, copy a script step from FM Pro, run
+    "detect" to see the exact format name FileMaker registers, then pass it
+    explicitly via --format-name on the write command.
+"""
+
+import argparse
+import base64
+import os
+import re
+import struct
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+
+# ---------------------------------------------------------------------------
+# FileMaker class / format name tables (same codes as clipboard.py / macOS)
+# ---------------------------------------------------------------------------
+
+FM_CLASSES = {
+    'XMSS': 'Script Steps',
+    'XMSC': 'Script',
+    'XML2': 'Layout Objects',
+    'XMLO': 'Layout Objects (legacy)',
+    'XMFD': 'Field Definition',
+    'XMFN': 'Custom Function',
+    'XMTB': 'Table',
+    'XMVL': 'Value List',
+    'XMTH': 'Theme',
+}
+
+XML_ELEMENT_TO_CLASS = {
+    'Step':           'XMSS',
+    'Script':         'XMSC',
+    'CustomFunction': 'XMFN',
+    'Field':          'XMFD',
+    'BaseTable':      'XMTB',
+    'ValueList':      'XMVL',
+    'Layout':         'XML2',
+    'Theme':          'XMTH',
+    'CustomMenu':     'ut16',
+    'CustomMenuSet':  'ut16',
+}
+
+# Default Windows clipboard format name prefix.
+# FileMaker on Windows uses "Mac-XMSS", "Mac-XMSC", etc. following the convention
+# Apple introduced with the Carbon cross-platform clipboard layer (FM7+).
+DEFAULT_WIN_PREFIX = 'Mac-'
+
+
+def _win_format_name(cls, prefix=DEFAULT_WIN_PREFIX):
+    return f'{prefix}{cls}'
+
+
+# ---------------------------------------------------------------------------
+# PowerShell Win32 type definition (shared across all PS scripts)
+# Embedded as a plain string -- no Python f-string interpolation here.
+# The here-string closing "@" must be at column 0 with no leading whitespace.
+# ---------------------------------------------------------------------------
+
+_PS_TYPE_DEF = '''\
+Add-Type -TypeDefinition @"
+using System;
+using System.Runtime.InteropServices;
+using System.Text;
+public static class FmClip {
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool OpenClipboard(IntPtr hWnd);
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool CloseClipboard();
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern bool EmptyClipboard();
+    [DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern uint RegisterClipboardFormat(string name);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern IntPtr GlobalAlloc(uint flags, UIntPtr size);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern IntPtr GlobalLock(IntPtr hMem);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern bool GlobalUnlock(IntPtr hMem);
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern IntPtr SetClipboardData(uint format, IntPtr hMem);
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern IntPtr GetClipboardData(uint format);
+    [DllImport("kernel32.dll", SetLastError=true)]
+    public static extern UIntPtr GlobalSize(IntPtr hMem);
+    [DllImport("user32.dll", SetLastError=true)]
+    public static extern uint EnumClipboardFormats(uint format);
+    [DllImport("user32.dll", SetLastError=true, CharSet=CharSet.Unicode)]
+    public static extern int GetClipboardFormatName(uint format, StringBuilder buf, int max);
+}
+"@
+
+'''
+
+# ---------------------------------------------------------------------------
+# Environment / PowerShell helpers
+# ---------------------------------------------------------------------------
+
+_ps_exe_cache = None
+_win_temp_cache = None
+
+
+def _require_powershell():
+    global _ps_exe_cache
+    if _ps_exe_cache:
+        return _ps_exe_cache
+    for candidate in (
+        'powershell.exe',
+        '/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe',
+    ):
+        try:
+            r = subprocess.run(
+                [candidate, '-NoProfile', '-Command', 'echo ok'],
+                capture_output=True, text=True, timeout=10,
+            )
+            if r.returncode == 0:
+                _ps_exe_cache = candidate
+                return candidate
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            continue
+    print('ERROR: powershell.exe not found. This script requires WSL2 on Windows.', file=sys.stderr)
+    sys.exit(1)
+
+
+def _get_win_temp() -> tuple:
+    """Return (wsl_path, windows_path) for the Windows TEMP directory."""
+    global _win_temp_cache
+    if _win_temp_cache:
+        return _win_temp_cache
+    ps = _require_powershell()
+    r = subprocess.run(
+        [ps, '-NoProfile', '-Command', '[System.IO.Path]::GetTempPath()'],
+        capture_output=True, text=True, timeout=10,
+    )
+    if r.returncode != 0 or not r.stdout.strip():
+        _win_temp_cache = ('/tmp', r'C:\Windows\Temp')
+        return _win_temp_cache
+    win_path = r.stdout.strip().rstrip('\\')
+    r2 = subprocess.run(['wslpath', win_path], capture_output=True, text=True)
+    wsl_path = r2.stdout.strip() if r2.returncode == 0 else '/tmp'
+    _win_temp_cache = (wsl_path, win_path)
+    return _win_temp_cache
+
+
+def _run_ps1(script_body: str) -> subprocess.CompletedProcess:
+    """Write script_body to a .ps1 file in Windows TEMP and execute it via powershell.exe."""
+    ps = _require_powershell()
+    wsl_temp, _win_temp = _get_win_temp()
+
+    fd, wsl_ps_path = tempfile.mkstemp(suffix='.ps1', dir=wsl_temp, prefix='fm_clip_')
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as f:
+            f.write(script_body)
+
+        r = subprocess.run(['wslpath', '-w', wsl_ps_path], capture_output=True, text=True)
+        if r.returncode != 0:
+            print(f'ERROR: wslpath -w failed: {r.stderr.strip()}', file=sys.stderr)
+            sys.exit(1)
+        win_ps_path = r.stdout.strip()
+
+        return subprocess.run(
+            [
+                ps, '-NoProfile', '-NonInteractive',
+                '-ExecutionPolicy', 'Bypass',
+                '-File', win_ps_path,
+            ],
+            capture_output=True, text=True, timeout=30,
+        )
+    finally:
+        try:
+            os.unlink(wsl_ps_path)
+        except OSError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# XML class detection (mirrors clipboard.py)
+# ---------------------------------------------------------------------------
+
+def detect_class_from_xml(xml_text: str) -> str:
+    try:
+        root = ET.fromstring(xml_text)
+        if len(root) > 0:
+            cls = XML_ELEMENT_TO_CLASS.get(root[0].tag)
+            if cls:
+                return cls
+    except ET.ParseError:
+        pass
+    for element in ('CustomMenuSet', 'CustomMenu'):
+        if re.search(rf'<{element}[\s>/]', xml_text):
+            return 'ut16'
+    for element, cls in XML_ELEMENT_TO_CLASS.items():
+        if element in ('CustomMenuSet', 'CustomMenu'):
+            continue
+        if re.search(rf'<{element}[\s>/]', xml_text):
+            return cls
+    return 'XMSS'
+
+
+# ---------------------------------------------------------------------------
+# write
+# ---------------------------------------------------------------------------
+
+def write_to_clipboard(input_path: str, cls: str = None, prefix: str = DEFAULT_WIN_PREFIX):
+    """Write an fmxmlsnippet XML file to the Windows clipboard as FM objects."""
+    with open(input_path, 'rb') as f:
+        raw_bytes = f.read()
+
+    if raw_bytes[:2] in (b'\xff\xfe', b'\xfe\xff'):
+        xml_text = raw_bytes.decode('utf-16')
+        raw_bytes = xml_text.encode('utf-8')
+    else:
+        xml_text = raw_bytes.decode('utf-8', errors='replace')
+
+    if cls is None:
+        cls = detect_class_from_xml(xml_text)
+    cls = cls.lower() if cls.lower() == 'ut16' else cls.upper()
+
+    if cls == 'ut16':
+        xml_text = re.sub(r'<\?xml[^?]*\?>\s*', '', xml_text, count=1)
+        raw_bytes = xml_text.encode('utf-16')
+    else:
+        # Strip XML declaration — FM on Windows stores raw XML without it
+        xml_clean = re.sub(r'<\?xml[^?]*\?>\s*', '', xml_text, count=1)
+        xml_bytes = xml_clean.encode('utf-8')
+        # Windows FM clipboard format: 4-byte little-endian length prefix + UTF-8 XML
+        raw_bytes = struct.pack('<I', len(xml_bytes)) + xml_bytes
+
+    if cls not in FM_CLASSES and cls != 'ut16':
+        print(f"ERROR: Unknown class '{cls}'. Valid: {', '.join(FM_CLASSES)}", file=sys.stderr)
+        sys.exit(1)
+
+    format_name = _win_format_name(cls, prefix)
+    # base64 alphabet contains only A-Z a-z 0-9 + / = -- safe in single-quoted PS string
+    b64 = base64.b64encode(raw_bytes).decode('ascii')
+
+    # Build the PowerShell script.
+    # _PS_TYPE_DEF is NOT an f-string so its { } are literal.
+    # The f-string below uses {{ }} for literal PS braces.
+    ps = _PS_TYPE_DEF + f"""\
+$formatName = '{format_name}'
+$bytes = [Convert]::FromBase64String('{b64}')
+
+$fmt = [FmClip]::RegisterClipboardFormat($formatName)
+if ($fmt -eq 0) {{
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Error "RegisterClipboardFormat failed (Win32 error $err)"
+    exit 1
+}}
+
+if (-not [FmClip]::OpenClipboard([IntPtr]::Zero)) {{
+    $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+    Write-Error "OpenClipboard failed (Win32 error $err)"
+    exit 1
+}}
+
+try {{
+    [FmClip]::EmptyClipboard() | Out-Null
+    $hMem = [FmClip]::GlobalAlloc([uint32]0x0002, [UIntPtr][uint64]$bytes.Length)
+    if ($hMem -eq [IntPtr]::Zero) {{
+        Write-Error "GlobalAlloc failed"
+        exit 1
+    }}
+    $ptr = [FmClip]::GlobalLock($hMem)
+    [System.Runtime.InteropServices.Marshal]::Copy($bytes, 0, $ptr, $bytes.Length)
+    [FmClip]::GlobalUnlock($hMem) | Out-Null
+    $r = [FmClip]::SetClipboardData($fmt, $hMem)
+    if ($r -eq [IntPtr]::Zero) {{
+        $err = [System.Runtime.InteropServices.Marshal]::GetLastWin32Error()
+        Write-Error "SetClipboardData failed (Win32 error $err)"
+        exit 1
+    }}
+    Write-Output 'OK'
+}} finally {{
+    [FmClip]::CloseClipboard() | Out-Null
+}}
+"""
+
+    result = _run_ps1(ps)
+    if result.returncode != 0 or 'OK' not in result.stdout:
+        err = result.stderr.strip() or result.stdout.strip() or 'unknown error'
+        print(f'ERROR: Clipboard write failed:\n{err}', file=sys.stderr)
+        sys.exit(1)
+
+    label = FM_CLASSES.get(cls, 'Menu')
+    print(f'Clipboard ready → {input_path} as {format_name} ({label})', file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# detect
+# ---------------------------------------------------------------------------
+
+def detect_clipboard_formats(prefix: str = DEFAULT_WIN_PREFIX):
+    """List all custom clipboard formats currently on the Windows clipboard."""
+    ps = _PS_TYPE_DEF + """\
+if (-not [FmClip]::OpenClipboard([IntPtr]::Zero)) {
+    Write-Error 'OpenClipboard failed'
+    exit 1
+}
+try {
+    $f = [uint32]0
+    $count = 0
+    while (($f = [FmClip]::EnumClipboardFormats($f)) -ne [uint32]0) {
+        $sb = New-Object System.Text.StringBuilder 256
+        $n = [FmClip]::GetClipboardFormatName($f, $sb, 256)
+        if ($n -gt 0) {
+            Write-Output ('{0,6}  {1}' -f $f, $sb.ToString())
+            $count++
+        }
+    }
+    if ($count -eq 0) { Write-Output '(none)' }
+} finally {
+    [FmClip]::CloseClipboard() | Out-Null
+}
+"""
+
+    result = _run_ps1(ps)
+    if result.returncode != 0:
+        print(f'ERROR: {result.stderr.strip()}', file=sys.stderr)
+        sys.exit(1)
+
+    lines = result.stdout.strip().splitlines()
+    if not lines or lines[0].strip() == '(none)':
+        print('No custom clipboard formats found.')
+        print('(Clipboard may be empty or contain only built-in formats like CF_TEXT.)')
+        return
+
+    fm_names = {_win_format_name(c, prefix) for c in list(FM_CLASSES) + ['ut16']}
+    print('Custom clipboard formats on the Windows clipboard:')
+    for line in lines:
+        print(f'  {line}')
+        for name in fm_names:
+            if name in line:
+                print(f'    ^ FileMaker format: {name}')
+
+    print()
+    print('Tip: if the FileMaker format name shown above differs from the default')
+    print(f'     prefix "{prefix}", re-run write with: --format-prefix <prefix>')
+
+
+# ---------------------------------------------------------------------------
+# read
+# ---------------------------------------------------------------------------
+
+def read_from_clipboard(output_path: str = None, prefix: str = DEFAULT_WIN_PREFIX):
+    """Read FileMaker objects from the Windows clipboard and output as XML."""
+    candidates = [_win_format_name(c, prefix) for c in FM_CLASSES] + [_win_format_name('ut16', prefix)]
+    candidates_ps = ', '.join(f"'{n}'" for n in candidates)
+
+    ps = _PS_TYPE_DEF + f"""\
+$candidates = @({candidates_ps})
+
+if (-not [FmClip]::OpenClipboard([IntPtr]::Zero)) {{
+    Write-Error 'OpenClipboard failed'
+    exit 1
+}}
+try {{
+    foreach ($name in $candidates) {{
+        $fmt = [FmClip]::RegisterClipboardFormat($name)
+        $hData = [FmClip]::GetClipboardData($fmt)
+        if ($hData -ne [IntPtr]::Zero) {{
+            $ptr = [FmClip]::GlobalLock($hData)
+            $sz = [uint64][FmClip]::GlobalSize($hData)
+            $bytes = New-Object byte[] $sz
+            [System.Runtime.InteropServices.Marshal]::Copy($ptr, $bytes, 0, [int]$sz)
+            [FmClip]::GlobalUnlock($hData) | Out-Null
+            Write-Output "FORMAT:$name"
+            Write-Output ([Convert]::ToBase64String($bytes))
+            break
+        }}
+    }}
+}} finally {{
+    [FmClip]::CloseClipboard() | Out-Null
+}}
+"""
+
+    result = _run_ps1(ps)
+    if result.returncode != 0:
+        print(f'ERROR: {result.stderr.strip()}', file=sys.stderr)
+        sys.exit(1)
+
+    lines = result.stdout.strip().splitlines()
+    if not lines or not lines[0].startswith('FORMAT:'):
+        print('ERROR: No FileMaker objects found on clipboard.', file=sys.stderr)
+        sys.exit(1)
+
+    format_name = lines[0][len('FORMAT:'):]
+    b64 = ''.join(lines[1:])
+    raw_bytes = base64.b64decode(b64)
+
+    if 'ut16' in format_name:
+        xml_text = raw_bytes.decode('utf-16')
+    else:
+        # Strip 4-byte little-endian length prefix written by FM on Windows
+        if len(raw_bytes) >= 4:
+            length = struct.unpack('<I', raw_bytes[:4])[0]
+            if length == len(raw_bytes) - 4:
+                raw_bytes = raw_bytes[4:]
+        xml_text = raw_bytes.decode('utf-8')
+
+    try:
+        fmt_result = subprocess.run(
+            ['xmllint', '--format', '-'],
+            input=xml_text.encode('utf-8'), capture_output=True,
+        )
+        if fmt_result.returncode == 0:
+            xml_text = fmt_result.stdout.decode('utf-8')
+    except FileNotFoundError:
+        pass
+
+    if output_path:
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(xml_text)
+        print(f'Saved {format_name} to {output_path}', file=sys.stderr)
+    else:
+        print(xml_text)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Read/write FileMaker fmxmlsnippets via the Windows clipboard from WSL2',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            'FM class codes: '
+            + ', '.join(f'{k}={v}' for k, v in FM_CLASSES.items())
+            + '\n\n'
+            'If FileMaker does not accept the paste, copy a script step from FM Pro, then\n'
+            'run "detect" to see the exact format name FM registers on this installation.\n'
+            'Pass the observed prefix via --format-prefix on the write command.'
+        ),
+    )
+    sub = parser.add_subparsers(dest='cmd')
+
+    wp = sub.add_parser('write', help='Write XML to Windows clipboard as FM objects')
+    wp.add_argument('input', help='fmxmlsnippet XML file')
+    wp.add_argument('--class', dest='cls', default=None,
+                    help='FM class override (default: auto-detect from XML). Use "ut16" for menus.')
+    wp.add_argument('--format-prefix', dest='prefix', default=DEFAULT_WIN_PREFIX,
+                    help=f'Windows format name prefix (default: "{DEFAULT_WIN_PREFIX}"). '
+                         'Use "" (empty) to try bare class codes like "XMSS".')
+
+    rp = sub.add_parser('read', help='Read FM objects from Windows clipboard as XML')
+    rp.add_argument('output', nargs='?', help='Output file (default: stdout)')
+    rp.add_argument('--format-prefix', dest='prefix', default=DEFAULT_WIN_PREFIX,
+                    help=f'Windows format name prefix (default: "{DEFAULT_WIN_PREFIX}").')
+
+    dp = sub.add_parser('detect', help='List custom clipboard formats (copy from FM first)')
+    dp.add_argument('--format-prefix', dest='prefix', default=DEFAULT_WIN_PREFIX,
+                    help=f'Prefix used to tag FileMaker formats in output (default: "{DEFAULT_WIN_PREFIX}").')
+
+    args = parser.parse_args()
+
+    if args.cmd == 'write':
+        write_to_clipboard(args.input, args.cls, args.prefix)
+    elif args.cmd == 'read':
+        read_from_clipboard(args.output, args.prefix)
+    elif args.cmd == 'detect':
+        detect_clipboard_formats(args.prefix)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -20,6 +20,7 @@ import argparse
 import json
 import logging
 import os
+import re
 import signal
 import subprocess
 import sys
@@ -50,6 +51,82 @@ def _read_local_version() -> str:
         return "unknown"
 
 VERSION = _read_local_version()
+
+# ---------------------------------------------------------------------------
+# Path helpers (WSL2 / Windows compatibility)
+# ---------------------------------------------------------------------------
+
+def _wsl_translate_path(path: str) -> str:
+    """Translate FileMaker's Windows-POSIX paths (/C:/...) to WSL2 mount points (/mnt/c/...).
+
+    FileMaker on Windows uses ConvertFromFileMakerPath(...; 1) which produces paths
+    like /C:/Users/... instead of the WSL2 equivalent /mnt/c/Users/...
+    """
+    m = re.match(r"^/([A-Za-z]):(.*)", path)
+    if m:
+        drive = m.group(1).lower()
+        rest = m.group(2)
+        return f"/mnt/{drive}{rest}"
+    return path
+
+
+def _load_automation_config() -> dict:
+    """Load agent/config/automation.json relative to this script, if present."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(here, "..", "config", "automation.json")
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+_automation_config: dict = _load_automation_config()
+
+
+def _resolve_export_path_for_wsl(solution_name: str) -> str:
+    """Resolve the FM export file path when FileMaker sends '?' on WSL2.
+
+    FileMaker on Windows exports via Get(DesktopPath) & Get(FileName) & ".xml".
+    When ConvertFromFileMakerPath fails (returns '?'), we reconstruct the path
+    by querying Windows for the actual Desktop shell folder via PowerShell
+    (handles OneDrive-redirected Desktops), then converting with wslpath.
+
+    Falls back to export_dir_override in automation.json if auto-detection fails.
+    """
+    # Config override takes precedence — skip auto-detection entirely
+    export_dir = _automation_config.get("export_dir_override", "")
+    if export_dir:
+        path = os.path.join(os.path.expanduser(export_dir), f"{solution_name}.xml")
+        log.info("Using export_dir_override from automation.json: %r", path)
+        return path
+
+    # Auto-detect via PowerShell + wslpath (WSL2 only).
+    # GetFolderPath('Desktop') resolves OneDrive-redirected Desktops correctly;
+    # a simple USERPROFILE\Desktop approach misses this common Windows setup.
+    try:
+        r1 = subprocess.run(
+            [
+                "powershell.exe", "-NoProfile", "-Command",
+                "[Environment]::GetFolderPath('Desktop')",
+            ],
+            capture_output=True, text=True, timeout=10,
+        )
+        if r1.returncode == 0:
+            win_desktop = r1.stdout.strip()  # e.g. C:\Users\pchov\OneDrive\Desktop
+            r2 = subprocess.run(
+                ["wslpath", win_desktop],
+                capture_output=True, text=True, timeout=5,
+            )
+            if r2.returncode == 0:
+                wsl_desktop = r2.stdout.strip()  # e.g. /mnt/c/Users/pchov/OneDrive/Desktop
+                path = os.path.join(wsl_desktop, f"{solution_name}.xml")
+                log.info("Auto-detected WSL2 export path via PowerShell+wslpath: %r", path)
+                return path
+    except Exception as exc:
+        log.warning("WSL2 export path auto-detection failed: %s", exc)
+
+    return ""
 
 # ---------------------------------------------------------------------------
 # Webviewer process state (module-level, shared across request threads)
@@ -261,6 +338,65 @@ class CompanionHandler(BaseHTTPRequestHandler):
         # Expand ~ in paths
         repo_path = os.path.expanduser(repo_path)
         export_file_path = os.path.expanduser(export_file_path)
+
+        # Translate Windows-POSIX paths (/C:/...) to WSL2 mount points (/mnt/c/...).
+        # FileMaker on Windows uses ConvertFromFileMakerPath(...; 1) which produces
+        # paths like /C:/Users/... that are invalid in WSL2.
+        export_file_path = _wsl_translate_path(export_file_path)
+        repo_path = _wsl_translate_path(repo_path)
+
+        # If repo_path is "?" it means FileMaker's ConvertFromFileMakerPath failed —
+        # this happens on WSL2 when the repo lives on the WSL filesystem and FileMaker
+        # on Windows cannot convert the \\wsl.localhost\... UNC path to a POSIX path.
+        # Fall back to repo_path_override from agent/config/automation.json.
+        if repo_path == "?":
+            override = _automation_config.get("repo_path_override", "")
+            if override:
+                repo_path = os.path.expanduser(override)
+                log.info(
+                    "repo_path was '?' — using repo_path_override from automation.json: %r",
+                    repo_path,
+                )
+            else:
+                self._send_json(
+                    {
+                        "success": False,
+                        "exit_code": -1,
+                        "error": (
+                            "repo_path is '?' — FileMaker could not convert the repo path to POSIX "
+                            "(common on WSL2 when the repo is on the WSL filesystem). "
+                            "Add 'repo_path_override' to agent/config/automation.json with the "
+                            "absolute POSIX path to your agentic-fm folder (e.g. /home/user/agentic-fm). "
+                            "See agent/docs/SANDBOXED_ENVIRONMENT.md for details."
+                        ),
+                    },
+                    status=400,
+                )
+                return
+
+        # If export_file_path is "?" FileMaker's ConvertFromFileMakerPath failed to
+        # produce a POSIX path for the Windows Desktop location. Reconstruct it from
+        # the Windows USERPROFILE env var via cmd.exe + wslpath, or from automation.json.
+        if export_file_path == "?":
+            resolved = _resolve_export_path_for_wsl(solution_name)
+            if resolved:
+                export_file_path = resolved
+            else:
+                self._send_json(
+                    {
+                        "success": False,
+                        "exit_code": -1,
+                        "error": (
+                            "export_file_path is '?' — FileMaker could not convert the Desktop path to POSIX "
+                            "and WSL2 auto-detection failed. "
+                            "Add 'export_dir_override' to agent/config/automation.json with the WSL2 path "
+                            "to your Windows Desktop (e.g. \"/mnt/c/Users/<you>/Desktop\"). "
+                            "See agent/docs/SANDBOXED_ENVIRONMENT.md for details."
+                        ),
+                    },
+                    status=400,
+                )
+                return
 
         # Build environment for subprocess
         env = os.environ.copy()
@@ -505,7 +641,7 @@ class CompanionHandler(BaseHTTPRequestHandler):
             self._send_json({"success": False, "error": str(exc)}, status=500)
 
     def _handle_clipboard(self):
-        """Accept XML content and write it to the macOS clipboard via clipboard.py."""
+        """Accept XML content and write it to the clipboard via clipboard.py (macOS) or clipboard_win.py (WSL2/Windows)."""
         try:
             body = self._read_body()
             payload = json.loads(body)
@@ -518,9 +654,16 @@ class CompanionHandler(BaseHTTPRequestHandler):
             self._send_json({"success": False, "error": "Missing required field: xml"}, status=400)
             return
 
+        import platform
         import tempfile
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        clipboard_py = os.path.join(script_dir, "clipboard.py")
+
+        # On Linux (WSL2), delegate to clipboard_win.py which uses powershell.exe.
+        # On macOS, use the original clipboard.py (osascript / NSPasteboard path).
+        if platform.system() == "Linux":
+            clipboard_py = os.path.join(script_dir, "clipboard_win.py")
+        else:
+            clipboard_py = os.path.join(script_dir, "clipboard.py")
 
         try:
             with tempfile.NamedTemporaryFile(
@@ -541,7 +684,7 @@ class CompanionHandler(BaseHTTPRequestHandler):
             else:
                 log.error("Clipboard write failed: %s", result.stderr)
                 self._send_json(
-                    {"success": False, "error": result.stderr or "clipboard.py returned non-zero"},
+                    {"success": False, "error": result.stderr or "clipboard script returned non-zero"},
                     status=500,
                 )
         except Exception as exc:


### PR DESCRIPTION
I ran into this issue running agentic-fm on Windows/WSL2.  There was no clipboard path for writing fmxmlsnippet XML in the format FileMaker Pro expects. Claude helped us discover the undocumented binary format and build the solution.

## What this adds

- `clipboard_win.py` for WSL2: writes fmxmlsnippet XML to the Windows clipboard using PowerShell P/Invoke (Mac-XMSS descriptor class). Supports read, write, and detect subcommands.
- **Key discovery:** FileMaker on Windows requires a 4-byte little-endian length prefix before the UTF-8 XML payload — this is undocumented and was found by comparing raw clipboard bytes from a real FM copy operation.
- The companion server's `/clipboard` endpoint now auto-routes to `clipboard_win.py` on Linux/WSL2 and `clipboard.py` on macOS.
- Documents the binary format in `CLIPBOARD.md`.
- Updates `automation.json.example` with Windows config notes.

## Testing

- Tested on WSL2 (Ubuntu) with FileMaker Pro on Windows host
- Verified fmxmlsnippet paste into FileMaker Script Workspace
- Confirmed companion server auto-detects platform and routes correctly
- macOS path unchanged — no regression for existing users

Usage note: When working with Claude in a WSL2 environment, the agent may default to the macOS clipboard path (clipboard.py / pbcopy) out of habit. If clipboard operations fail, remind Claude that you're on Windows/WSL2 and it should use clipboard_win.py or route through the companion server's /clipboard endpoint, which auto-detects the platform. Once pointed in the right direction, it works reliably.