### PR TITLE
Add trace.py confirm: batch the dead-object judgment layer

### DIFF
--- a/agent/scripts/layout_to_summary.py
+++ b/agent/scripts/layout_to_summary.py
@@ -330,6 +330,17 @@ def parse_portal(obj_el):
     if to_ref is not None:
         result["relatedTO"] = to_ref.get("name", "")
 
+    # Filter calculation ("Filter portal records"). Stored as a <Calculation>
+    # that is a *direct* child of <Portal> (siblings: TableOccurrenceReference,
+    # Options, SortSpecification, ObjectList). It reads the fields it names at
+    # display time, so without capturing it a field used only in a portal filter
+    # is invisible to the xref index and false-flagged as dead.
+    filter_calc = portal.find("Calculation")
+    if filter_calc is not None:
+        calc_text = filter_calc.find(".//Text")
+        if calc_text is not None and calc_text.text and calc_text.text.strip():
+            result["filter"] = calc_text.text.strip()
+
     # Row count
     opts = portal.find("Options")
     if opts is not None:
@@ -398,12 +409,22 @@ def parse_conditions(obj_el):
         if find_mode == "True":
             result["hideInFind"] = True
 
-    # Conditional formatting (just count, not full details)
+    # Conditional formatting. Keep the count for the compact view, plus the
+    # condition calc text — each <Condition> carries a <Calculation> that reads
+    # the fields it names, so dropping it hides conditional-format-only fields
+    # from the xref index (false "dead" verdicts).
     formatting = conds.find("Formatting")
     if formatting is not None:
         count = formatting.get("membercount", "0")
         if int(count) > 0:
             result["conditionalFormats"] = int(count)
+        cf_calcs = []
+        for cond in formatting.findall("Condition"):
+            calc = cond.find(".//Text")
+            if calc is not None and calc.text and calc.text.strip():
+                cf_calcs.append(calc.text.strip())
+        if cf_calcs:
+            result["conditionalFormatCalcs"] = cf_calcs
 
     return result if result else None
 
@@ -471,10 +492,15 @@ def parse_action_script(el):
             if child.tag == "action":
                 script_ref = child.find("ScriptReference")
                 if script_ref is not None and script_ref.get("name"):
-                    result.append({
+                    entry = {
                         "script": script_ref.get("name"),
                         "scriptId": int(script_ref.get("id", 0)),
-                    })
+                    }
+                    # Script parameter calc — reads the fields it names.
+                    calc = child.find(".//Text")
+                    if calc is not None and calc.text and calc.text.strip().strip('"'):
+                        entry["param"] = calc.text.strip().strip('"')
+                    result.append(entry)
                     return
             else:
                 _find(child)

--- a/agent/scripts/trace.py
+++ b/agent/scripts/trace.py
@@ -56,6 +56,22 @@ XRef = namedtuple("XRef", [
 ])
 
 
+# Dead-object candidate computation shared by `dead` and `confirm`. Carries the
+# raw inputs (xrefs + the object sets) alongside the four classified buckets so
+# `confirm` can enrich candidates without recomputing.
+DeadResult = namedtuple("DeadResult", [
+    "xrefs",            # all XRef rows from xref.index
+    "all_objects",      # set of every object of this type
+    "on_layout",        # {obj_name: [layout_names]} — placed on a layout
+    "system_excluded",  # set excluded by system heuristics (PKs, FKs, globals, summaries)
+    "module_objects",   # {obj_name: module_label} — installed-tool objects (live)
+    "high",             # no references found anywhere
+    "medium",           # on a layout but not in scripts/calcs
+    "low",              # excluded by heuristics
+    "module",           # module objects (live, invoked externally)
+])
+
+
 # ---------------------------------------------------------------------------
 # Built-in auto-enter type keywords (not field references)
 # ---------------------------------------------------------------------------
@@ -869,31 +885,42 @@ def cmd_query(solution_name, ref_type, ref_name, direction):
 # Dead object scan
 # ---------------------------------------------------------------------------
 
-def cmd_dead(solution_name, obj_type, verbose):
-    """Find unreferenced objects."""
+def _dead_reliability_warning(solution_name, obj_type, xrefs):
+    """Emit the layout-refs reliability warning when those edges are missing.
+
+    Dead-object detection for scripts/fields/value_lists leans on layout
+    references (placements, button scripts, triggers). If the xref has no
+    layout-sourced refs, those edges are missing and the results will
+    over-report "dead" objects. Warn loudly rather than mislead a human about to
+    delete things. Shared by `dead` and `confirm`.
+    """
+    if obj_type not in ("scripts", "fields", "value_lists"):
+        return
+    has_layout_refs = any(ref.source_type == "layout" for ref in xrefs)
+    if has_layout_refs:
+        return
+    print(
+        "⚠️  WARNING: xref.index contains NO layout references — "
+        f"'{obj_type}' dead results are UNRELIABLE.\n"
+        "    Layout placements, button scripts and script triggers are "
+        "missing, so trigger-only / layout-only objects will be "
+        "falsely flagged as dead.\n"
+        "    Regenerate layout summaries and rebuild before trusting "
+        "this output:\n"
+        f"      python3 agent/scripts/layout_to_summary.py --solution \"{solution_name}\"\n"
+        f"      python3 agent/scripts/trace.py build -s \"{solution_name}\"\n",
+        file=sys.stderr,
+    )
+
+
+def compute_dead_candidates(solution_name, obj_type):
+    """Compute unreferenced objects classified into confidence buckets.
+
+    Pure computation (no printing) shared by `dead` and `confirm`. Returns a
+    DeadResult with the four buckets plus the raw inputs the caller may need.
+    """
     solution_dir = CONTEXT_DIR / solution_name
     xrefs = load_xref(solution_dir)
-
-    # Reliability guard: dead-object detection for scripts/fields/value_lists
-    # leans on layout references (placements, button scripts, triggers). If the
-    # xref has no layout-sourced refs, those edges are missing and the results
-    # will over-report "dead" objects. Warn loudly rather than mislead a
-    # human about to delete things.
-    if obj_type in ("scripts", "fields", "value_lists"):
-        has_layout_refs = any(ref.source_type == "layout" for ref in xrefs)
-        if not has_layout_refs:
-            print(
-                "⚠️  WARNING: xref.index contains NO layout references — "
-                f"'{obj_type}' dead results are UNRELIABLE.\n"
-                "    Layout placements, button scripts and script triggers are "
-                "missing, so trigger-only / layout-only objects will be "
-                "falsely flagged as dead.\n"
-                "    Regenerate layout summaries and rebuild before trusting "
-                "this output:\n"
-                f"      python3 agent/scripts/layout_to_summary.py --solution \"{solution_name}\"\n"
-                f"      python3 agent/scripts/trace.py build -s \"{solution_name}\"\n",
-                file=sys.stderr,
-            )
 
     # Build set of all referenced objects by type
     referenced = set()
@@ -924,6 +951,24 @@ def cmd_dead(solution_name, obj_type, verbose):
             medium.append(obj)
         else:
             high.append(obj)
+
+    return DeadResult(
+        xrefs, all_objects, on_layout, system_excluded, module_objects,
+        high, medium, low, module,
+    )
+
+
+def cmd_dead(solution_name, obj_type, verbose):
+    """Find unreferenced objects."""
+    res = compute_dead_candidates(solution_name, obj_type)
+    xrefs = res.xrefs
+    on_layout = res.on_layout
+    module_objects = res.module_objects
+    high, medium, low, module = res.high, res.medium, res.low, res.module
+    all_objects = res.all_objects
+
+    # Reliability guard (shared with confirm)
+    _dead_reliability_warning(solution_name, obj_type, xrefs)
 
     # Display
     print(f"=== Potentially unused {obj_type} ({solution_name}) ===\n")
@@ -1111,6 +1156,598 @@ def _get_all_objects(solution_dir, solution_name, obj_type, xrefs):
 
 
 # ---------------------------------------------------------------------------
+# Confirm — batch the deterministic judgment layer over dead candidates
+# ---------------------------------------------------------------------------
+
+# Names matching these patterns are external entry points (called by OData /
+# fmurlscript / a scheduler / an import pipeline), so a zero-inbound count does
+# NOT mean dead — flag for human review rather than auto-judging.
+ENTRY_POINT_RE = re.compile(
+    r'(^(Import|Populate|Export|Sync|Schedule|Cron|Webhook|API|Generate)\b)'
+    r'|(JSON|SearchIndex|Release_?Notes|Batch|Nightly)',
+    re.IGNORECASE,
+)
+
+
+# Name-string hit KINDS, by how live a literal mention is. A mention in cosmetic
+# text (a placeholder/label) cannot invoke anything; a mention in a calc/hideWhen
+# is a live reference; a mention in a Perform-Script/Go-to-Layout step is a caller.
+# Surfaced so the operator can accept/dismiss a `review` row at a glance instead of
+# re-opening it. Labeling only — it does NOT change disposition.
+HIT_KIND_RANK = {"benign": 0, "calc": 1, "caller": 2}
+
+# Layout-summary JSON keys whose string values are purely cosmetic (cannot
+# reference/invoke the candidate). Everything else defaults to "calc" (rescue).
+_LAYOUT_BENIGN_KEYS = {
+    "placeholder", "tooltip", "label", "text", "styleName", "displayName",
+    "theme", "iconDesc", "style", "class",
+}
+_LAYOUT_CALLER_KEYS = {"script"}
+
+
+# Merge-field syntax inside any text/label — `<<Table::Field>>` or `<<Field>>`.
+# A merge field is a LIVE data reference (it renders the field's value on the
+# layout), NOT cosmetic text — so its hit must be classified `calc`, never benign,
+# regardless of which key the surrounding text sits under.
+RE_MERGE_FIELD = re.compile(r'<<[^<>]+>>')
+
+
+def _layout_segments(obj, out):
+    """Flatten a layout summary into (kind, text) segments by JSON key context."""
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            if isinstance(v, str):
+                if k in _LAYOUT_BENIGN_KEYS:
+                    kind = "benign"
+                elif k in _LAYOUT_CALLER_KEYS:
+                    kind = "caller"
+                else:
+                    kind = "calc"
+                out.append((kind, v))
+                # Any embedded merge field is a live reference even when the
+                # surrounding value is cosmetic (e.g. a static-text block).
+                if kind != "calc" and "<<" in v:
+                    for mf in RE_MERGE_FIELD.findall(v):
+                        out.append(("calc", mf))
+            else:
+                _layout_segments(v, out)
+    elif isinstance(obj, list):
+        for item in obj:
+            _layout_segments(item, out)
+
+
+def _script_segments(text):
+    """Split a sanitized script into (kind, line) segments by step context."""
+    segs = []
+    for line in text.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        if s.startswith("#"):
+            kind = "benign"  # comment
+        elif "Perform Script" in s or "Go to Layout" in s:
+            kind = "caller"  # a name here is (or could be) a live call target
+        else:
+            kind = "calc"
+        segs.append((kind, line))
+    return segs
+
+
+def build_name_corpus(solution_name, solution_dir, fields_index, cf_names):
+    """Collect every place an object NAME could appear as a literal string.
+
+    Returns a list of {kind, origin, name, segments, text} entries spanning
+    sanitized scripts, layout summaries, field calcs and custom-function bodies.
+    `segments` is a list of (hit_kind, text) so a hit can be labelled benign /
+    calc / caller; `text` is the joined body (for dynamic-construct scanning).
+    This is the dynamic-dispatch blind-spot catch: a name appearing as a literal
+    string (Perform Script by name, a calculated layout name, ExecuteSQL) is
+    invisible to the structured xref parser but visible here.
+    """
+    corpus = []
+
+    def _add(kind, origin, name, segments):
+        corpus.append({
+            "kind": kind,
+            "origin": origin,
+            "name": name,
+            "segments": segments,
+            "text": "\n".join(t for _, t in segments),
+        })
+
+    # Scripts (reuse parse_scripts' filename convention)
+    scripts_dir = XML_PARSED_DIR / "scripts_sanitized" / solution_name
+    if scripts_dir.exists():
+        for txt_path in sorted(scripts_dir.rglob("*.txt")):
+            m = re.match(r'^(.+?)\s*-\s*ID\s+(\d+)\.txt$', txt_path.name)
+            if not m:
+                continue
+            try:
+                text = txt_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            _add("script", f"{m.group(1)} (ID {m.group(2)})", m.group(1),
+                 _script_segments(text))
+
+    # Layout summaries (segmented by key — placeholder/label vs hideWhen/param)
+    layouts_dir = solution_dir / "layouts"
+    if layouts_dir.exists():
+        for jp in sorted(layouts_dir.glob("*.json")):
+            try:
+                data = json.loads(jp.read_text(encoding="utf-8"))
+            except (json.JSONDecodeError, OSError):
+                continue
+            base = jp.stem  # "Layout Name - ID nn"
+            segs = []
+            _layout_segments(data, segs)
+            _add("layout", base, base.rsplit(" - ID", 1)[0], segs)
+
+    # Field calcs / auto-enter (reuse the auto:/calc: prefix convention)
+    for row in fields_index:
+        auto = row.get("auto_enter", "")
+        if auto.startswith("auto:") or auto.startswith("calc:"):
+            canonical = f"{row['table']}::{row['field']}"
+            _add("field_calc", canonical, canonical, [("calc", auto[5:])])
+
+    # Custom function bodies
+    for cf in cf_names:
+        if not cf["path"].exists():
+            continue
+        try:
+            text = cf["path"].read_text(encoding="utf-8")
+        except OSError:
+            continue
+        _add("custom_func", f"{cf['name']} (ID {cf['id']})", cf["name"],
+             [("calc", text)])
+
+    return corpus
+
+
+def scan_dynamic_constructs(corpus):
+    """Solution-level presence of dynamic-dispatch constructs (booleans).
+
+    These let a name reach an object without a structured reference. Combined
+    with a name-string hit (see cmd_confirm) they raise dynamic-reachable.
+    """
+    all_text = "\n".join(e["text"] for e in corpus)
+    return {
+        "ExecuteSQL": bool(re.search(r'ExecuteSQL\s*\(', all_text)),
+        "SetFieldByName": bool(re.search(r'Set Field By Name\s*\[', all_text)),
+        "GoToLayoutByVar": bool(re.search(r'Go to Layout\s*\[\s*Layoutname:', all_text)),
+        "Evaluate": bool(re.search(r'\bEvaluate\s*\(', all_text)),
+        "PerformByName": bool(re.search(r'Perform Script\s*\[\s*Specified:\s*By name', all_text)),
+    }
+
+
+def canvas_verdict(bounds, width, canvas_height, nested):
+    """Classify a single placement's position relative to the canvas.
+
+    off-canvas only when an object is FULLY outside the canvas on one axis.
+    Nested objects (inside a Portal/Group/Button Bar) report bounds in a parent
+    coordinate space in some FM versions, so their off-canvas reading is marked
+    low-confidence ('off-canvas?') and must never drive a delete on its own.
+    """
+    top, left, bottom, right = bounds
+    if width <= 0:
+        return "unknown"
+    if right <= left or bottom <= top:
+        return "zero-size"
+    off = (
+        left >= width
+        or right <= 0
+        or (canvas_height > 0 and top >= canvas_height)
+        or bottom <= 0
+    )
+    if off:
+        return "off-canvas?" if nested else "off-canvas"
+    return "on-canvas"
+
+
+def build_layout_object_index(solution_dir, to_map):
+    """Map canonical field -> [placement verdicts] from layout summaries.
+
+    Reuses the bounds/width data layout_to_summary.py already emits, so no raw
+    layout XML is re-read. Tracks nesting depth so child-object bounds are
+    flagged low-confidence (parent coordinate space).
+    """
+    index = {}
+    layouts_dir = solution_dir / "layouts"
+    if not layouts_dir.exists():
+        return index
+
+    def _walk(obj, nested, width, canvas_height, layout_name):
+        if isinstance(obj, dict):
+            bounds = obj.get("bounds")
+            field = obj.get("field")
+            if bounds and isinstance(field, str) and "::" in field:
+                to_name, fname = field.split("::", 1)
+                canonical, _ = resolve_to_field(to_name.strip(), fname.strip(), to_map)
+                index.setdefault(canonical, []).append({
+                    "layout": layout_name,
+                    "verdict": canvas_verdict(bounds, width, canvas_height, nested),
+                })
+            # Recurse into container children (Group/Portal objects, Button Bar buttons)
+            for key in ("objects", "buttons"):
+                for child in obj.get(key, []) or []:
+                    _walk(child, True, width, canvas_height, layout_name)
+
+    for jp in sorted(layouts_dir.glob("*.json")):
+        try:
+            data = json.loads(jp.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        width = int(data.get("width", 0) or 0)
+        canvas_height = sum(int(p.get("height", 0) or 0) for p in data.get("parts", []))
+        layout_name = data.get("layout", jp.stem)
+        for part in data.get("parts", []):
+            for obj in part.get("objects", []) or []:
+                _walk(obj, False, width, canvas_height, layout_name)
+
+    return index
+
+
+def aggregate_canvas(canonical_field, layout_index):
+    """Aggregate a field's placements into one verdict + placement count.
+
+    Any on-canvas (or unknown — assumed visible) placement ⇒ on-canvas (the
+    field is reachable by a user). Only when EVERY placement is parked do we
+    report off-canvas. Returns (verdict, n_placements) or (None, 0).
+    """
+    places = layout_index.get(canonical_field, [])
+    if not places:
+        return None, 0
+    verdicts = [p["verdict"] for p in places]
+    n = len(places)
+    if any(v in ("on-canvas", "unknown") for v in verdicts):
+        return "on-canvas", n
+    if any(v == "off-canvas" for v in verdicts):
+        return "off-canvas", n
+    if any(v == "off-canvas?" for v in verdicts):
+        return "off-canvas?", n
+    return "zero-size", n
+
+
+def name_string_hits(probes, is_self, corpus, is_live_referrer=None):
+    """Count literal name-string hits across the corpus, SELF vs EXTERNAL.
+
+    probes: list of literal strings to search (word-bounded). is_self(entry):
+    True when the corpus entry is the candidate's own definition (so a script
+    mentioning its own name in a header comment doesn't rescue itself).
+
+    Counting is per-origin (one entry = at most one hit) — identical to before,
+    so dispositions are unchanged. Each matching origin is additionally labelled
+    by the most-live segment it matched (benign < calc < caller); the aggregate
+    external `hit_kind` lets the operator triage the `review` bucket at a glance.
+    """
+    pats = [
+        re.compile(r'(?<![A-Za-z0-9_])' + re.escape(p) + r'(?![A-Za-z0-9_])')
+        for p in probes if p
+    ]
+    external = 0
+    self_hits = 0
+    samples = []
+    ext_kind = None
+    has_live_referrer = False  # a calc/caller hit whose referrer is itself live (kept)
+    live_referrer = None
+    held_referrer = None       # a calc/caller hit whose referrer is itself a candidate
+    for entry in corpus:
+        best = None
+        for skind, stext in entry["segments"]:
+            if any(p.search(stext) for p in pats):
+                if best is None or HIT_KIND_RANK[skind] > HIT_KIND_RANK[best]:
+                    best = skind
+        if best is None:
+            continue
+        if is_self(entry):
+            self_hits += 1
+        else:
+            external += 1
+            if ext_kind is None or HIT_KIND_RANK[best] > HIT_KIND_RANK[ext_kind]:
+                ext_kind = best
+            # Referrer-liveness: a calc/caller reference is only a confident "keep"
+            # if the referring object is itself live (not a removal candidate).
+            if best in ("calc", "caller") and is_live_referrer is not None:
+                if is_live_referrer(entry):
+                    has_live_referrer = True
+                    if live_referrer is None:
+                        live_referrer = entry["origin"]
+                elif held_referrer is None:
+                    held_referrer = entry["origin"]
+            if len(samples) < 2:
+                samples.append((entry["kind"], entry["origin"], best))
+    return {"external": external, "self": self_hits,
+            "samples": samples, "hit_kind": ext_kind,
+            "has_live_referrer": has_live_referrer,
+            "live_referrer": live_referrer, "held_referrer": held_referrer}
+
+
+def external_entry_hint(display_name):
+    """Return the matched entry-point token if name looks like an external entry point."""
+    target = display_name.split("::", 1)[1] if "::" in display_name else display_name
+    m = ENTRY_POINT_RE.search(target)
+    return m.group(0) if m else None
+
+
+# Which dynamic constructs can reach each object type
+_DYNAMIC_FOR_TYPE = {
+    "scripts": ("PerformByName", "Evaluate"),
+    "fields": ("SetFieldByName", "ExecuteSQL", "Evaluate"),
+    "layouts": ("GoToLayoutByVar",),
+    "value_lists": ("Evaluate",),
+    "custom_functions": ("Evaluate",),
+}
+
+
+def _candidate_probes(obj_type, name, unique_field_names=None):
+    """Literal name strings to search for this candidate.
+
+    For fields, always probe the qualified `Table::Field`. The bare field name is
+    added ONLY when it is unique across tables — otherwise it collides with a
+    same-named field on another table, falsely attributing the other field's
+    references to this candidate. The bare probe is still needed for unqualified
+    merge fields like `<<FieldName>>`, which is exactly why it is kept for unique
+    names.
+    """
+    if obj_type == "fields" and "::" in name:
+        field = name.split("::", 1)[1]
+        probes = [name]
+        if unique_field_names is None or field in unique_field_names:
+            probes.append(field)
+        return probes
+    return [name]
+
+
+def _candidate_self_test(obj_type, name):
+    """Predicate: is a corpus entry this candidate's OWN definition?"""
+    kind = {
+        "scripts": "script", "fields": "field_calc",
+        "custom_functions": "custom_func", "layouts": "layout",
+    }.get(obj_type)
+    if kind is None:  # value_lists have no body text of their own
+        return lambda e: False
+    return lambda e: e["kind"] == kind and e["name"] == name
+
+
+def _enrich_candidate(name, bucket, obj_type, corpus, dyn_flags,
+                      layout_index, on_layout, canvas_strict,
+                      unique_field_names=None, is_live_referrer=None):
+    """Compute all deterministic signals + a conservative disposition."""
+    hits = name_string_hits(_candidate_probes(obj_type, name, unique_field_names),
+                            _candidate_self_test(obj_type, name), corpus,
+                            is_live_referrer)
+
+    relevant = _DYNAMIC_FOR_TYPE.get(obj_type, ())
+    construct_present = any(dyn_flags.get(c) for c in relevant)
+    # A benign-only hit (placeholder/label/comment) can't be a dynamic call target,
+    # so require a calc/caller-kind external hit. Disposition-neutral: dynamic
+    # "possible" only ever co-occurs with external>0, which already rescues.
+    live_hit = hits.get("hit_kind") in ("calc", "caller")
+    dynamic = "possible" if (live_hit and construct_present) else "none"
+
+    canvas, canvas_n = (None, 0)
+    if obj_type == "fields":
+        canvas, canvas_n = aggregate_canvas(name, layout_index)
+
+    entry = external_entry_hint(name)
+
+    # Conservative disposition — never auto-delete. likely-dead only when every
+    # structural/name/dynamic/entry signal is silent (and, under --canvas-strict,
+    # the field is not on-canvas).
+    # Referrer-liveness promotion is scoped to FIELDS: field probes are
+    # table-qualified (or unique-bare), so a calc/caller hit precisely identifies
+    # the field. Layout/VL/script names are unqualified and can collide with table
+    # names, keywords and literals (a layout whose name matches a table name; a
+    # value list named after a boolean/keyword), so promoting those on a
+    # name-string hit would falsely mark a dead object live. Those types stay on
+    # conservative review.
+    promote_live = obj_type == "fields" and hits.get("has_live_referrer")
+    if promote_live:
+        # Referenced (calc/caller) by an object that is itself live/kept — the
+        # candidate is therefore kept too. Confident enough to skip at a glance.
+        disposition = "likely-live"
+    elif entry:
+        disposition = "review"
+    elif dynamic == "possible":
+        disposition = "review"
+    elif hits["external"] > 0:
+        # External hit(s), but the referrer is itself a removal candidate (held) or
+        # the hit is cosmetic (benign) — genuinely ambiguous, needs a human.
+        disposition = "review"
+    elif canvas == "on-canvas":
+        # Visibly placed on a layout (even if the structured xref missed it via a
+        # TO-resolution mismatch) — present to users, never auto-judge as dead.
+        disposition = "review"
+    elif bucket == "medium":
+        if canvas_strict and obj_type == "fields" and canvas in ("off-canvas", "off-canvas?", "zero-size"):
+            disposition = "likely-dead"
+        else:
+            disposition = "review"
+    else:
+        disposition = "likely-dead"
+
+    return {
+        "name": name,
+        "bucket": bucket,
+        "name_string_hits": hits,
+        "hit_kind": hits.get("hit_kind"),  # benign / calc / caller (external hits)
+        # Referrer-liveness is only reliable for fields (precise probes) — see above.
+        "live_referrer": hits.get("live_referrer") if obj_type == "fields" else None,
+        "held_referrer": hits.get("held_referrer") if obj_type == "fields" else None,
+        "dynamic_reachable": dynamic,
+        "canvas": canvas,
+        "canvas_placements": canvas_n,
+        "on_layout": on_layout.get(name, []),
+        "external_entry_point": entry,
+        "disposition": disposition,
+    }
+
+
+def cmd_confirm(solution_name, obj_type, as_json, verbose, canvas_strict):
+    """Enrich dead candidates with batched deterministic judgment signals."""
+    solution_dir = CONTEXT_DIR / solution_name
+    res = compute_dead_candidates(solution_name, obj_type)
+
+    # Same reliability guard as `dead` — confirm inherits the same blind spot.
+    _dead_reliability_warning(solution_name, obj_type, res.xrefs)
+
+    # Global pre-scans, built once
+    fields_index = load_fields_index(solution_dir)
+    cf_names = build_cf_names(solution_name)
+    to_index = load_table_occurrences_index(solution_dir)
+    to_map = build_to_map(to_index)
+
+    corpus = build_name_corpus(solution_name, solution_dir, fields_index, cf_names)
+    dyn_flags = scan_dynamic_constructs(corpus)
+    layout_index = build_layout_object_index(solution_dir, to_map) if obj_type == "fields" else {}
+
+    # Field names that are unique across tables — the bare field-name probe is only
+    # safe for these (otherwise it collides with a same-named field on another table).
+    name_tables = {}
+    for row in fields_index:
+        name_tables.setdefault(row["field"], set()).add(row["table"])
+    unique_field_names = {f for f, tabs in name_tables.items() if len(tabs) == 1}
+
+    # Removal-candidate (high∪medium) sets per type, for referrer-liveness. A
+    # referrer is "live" when it is NOT itself a removal candidate.
+    dead_sets = {obj_type: set(res.high) | set(res.medium)}
+    for ty in ("scripts", "layouts", "fields", "custom_functions", "value_lists"):
+        if ty in dead_sets:
+            continue
+        r = compute_dead_candidates(solution_name, ty)
+        dead_sets[ty] = set(r.high) | set(r.medium)
+    _corpus_kind_to_type = {
+        "script": "scripts", "layout": "layouts",
+        "field_calc": "fields", "custom_func": "custom_functions",
+    }
+
+    def is_live_referrer(entry):
+        ty = _corpus_kind_to_type.get(entry["kind"])
+        if ty is None:
+            return False
+        return entry["name"] not in dead_sets.get(ty, set())
+
+    def enrich(name, bucket):
+        return _enrich_candidate(name, bucket, obj_type, corpus, dyn_flags,
+                                 layout_index, res.on_layout, canvas_strict,
+                                 unique_field_names, is_live_referrer)
+
+    enriched = []
+    for name in res.high:
+        enriched.append(enrich(name, "high"))
+    for name in res.medium:
+        enriched.append(enrich(name, "medium"))
+    if verbose:
+        for name in res.low:
+            row = enrich(name, "low")
+            row["disposition"] = "likely-live"  # heuristic-excluded (PK/FK/global/summary)
+            enriched.append(row)
+
+    tally = {"likely-dead": 0, "review": 0, "likely-live": 0}
+    for row in enriched:
+        tally[row["disposition"]] = tally.get(row["disposition"], 0) + 1
+
+    heuristic_notes = [
+        "likely-live = referenced (calc/caller) by an object that is itself LIVE (not a removal "
+        "candidate) — keep at a glance, no source-open needed. review is reserved for the genuinely "
+        "ambiguous: an entry-point name, a dynamic-reachable hit, OR a referrer that is itself a "
+        "held/dead candidate (held-ref — its fate decides this one).",
+        "HIT-KIND labels an external name-string hit: benign (placeholder/label/tooltip — "
+        "cannot invoke) < calc (hideWhen/merge/calc — live reference) < caller "
+        "(Perform-by-name/Go-to-Layout-$var).",
+        "Field probes are table-qualified: the bare field name is only matched when unique across "
+        "tables, so a same-named field on another table can't cross-rescue.",
+        "off-canvas is informational by default and never the sole basis for likely-dead"
+        + (" (--canvas-strict ON: off-canvas demotes a medium field)" if canvas_strict else ""),
+        "likely-dead = every structural/name-string/dynamic/entry-point signal silent",
+        "nested-object off-canvas is low-confidence (off-canvas?) — parent coordinate space",
+        "VERIFY before deleting: a wrong delete removes live schema",
+    ]
+
+    if as_json:
+        print(json.dumps({
+            "solution": solution_name,
+            "type": obj_type,
+            "canvas_strict": canvas_strict,
+            "dynamic_constructs_present": dyn_flags,
+            "heuristic_notes": heuristic_notes,
+            "candidates": enriched,
+            "tally": tally,
+        }, indent=2, ensure_ascii=False))
+        return
+
+    _render_confirm_table(solution_name, obj_type, res, enriched, tally,
+                          dyn_flags, heuristic_notes, canvas_strict)
+
+
+def _render_confirm_table(solution_name, obj_type, res, enriched, tally,
+                          dyn_flags, heuristic_notes, canvas_strict):
+    """Print the one-read enriched candidate table."""
+    print(f"=== Dead-object confirmation: {obj_type} ({solution_name}) ===")
+    strict = "ON" if canvas_strict else "OFF (informational)"
+    print(f"Candidates enriched: {len(enriched)} "
+          f"(from {len(res.high)} high + {len(res.medium)} medium"
+          + (f" + {len(res.low)} low" if any(r['bucket'] == 'low' for r in enriched) else "")
+          + f")   |   --canvas-strict: {strict}")
+    present = [k for k, v in dyn_flags.items() if v]
+    print(f"Dynamic constructs in solution: {', '.join(present) if present else 'none'}\n")
+
+    if not enriched:
+        print("No dead candidates to confirm.\n")
+        return
+
+    rows = []
+    for r in enriched:
+        h = r["name_string_hits"]
+        if obj_type == "fields" and r["canvas"]:
+            layout_col = f"{r['canvas']}({r['canvas_placements']})"
+        elif r["on_layout"]:
+            ls = ", ".join(r["on_layout"][:2])
+            layout_col = ls + (f" +{len(r['on_layout']) - 2}" if len(r["on_layout"]) > 2 else "")
+        else:
+            layout_col = "-"
+        notes = []
+        if r.get("live_referrer"):
+            notes.append(f"live-ref: {r['live_referrer']}")
+        elif r.get("held_referrer"):
+            notes.append(f"held-ref: {r['held_referrer']} (its fate decides this)")
+        if r["external_entry_point"]:
+            notes.append(f"name: {r['external_entry_point']}")
+        if h["samples"] and not r.get("live_referrer"):
+            notes.append("hit " + ",".join(f"{fk}@{o}" for _k, o, fk in h["samples"])[:40])
+        rows.append([
+            r["disposition"],
+            r["name"][:42],
+            f"{h['external']}/{h['self']}",
+            r["hit_kind"] or "-",
+            r["dynamic_reachable"],
+            layout_col[:24],
+            r["external_entry_point"] or "-",
+            "; ".join(notes)[:48],
+        ])
+
+    headers = ["DISPOSITION", "CANDIDATE", "HITS e/s", "HIT-KIND", "DYNAMIC", "ON-LAYOUT/CANVAS", "ENTRY", "NOTES"]
+    widths = [max(len(headers[i]), max((len(r[i]) for r in rows), default=0)) for i in range(len(headers))]
+    # Sort: likely-dead first (most actionable), then review, then likely-live
+    order = {"likely-dead": 0, "review": 1, "likely-live": 2}
+    rows.sort(key=lambda r: (order.get(r[0], 9), r[1].lower()))
+
+    def fmt(cells):
+        return " | ".join(c.ljust(widths[i]) for i, c in enumerate(cells))
+
+    print(fmt(headers))
+    print("-+-".join("-" * w for w in widths))
+    for r in rows:
+        print(fmt(r))
+    print("-+-".join("-" * w for w in widths))
+
+    print(f"\nDisposition tally: {tally['likely-dead']} likely-dead, "
+          f"{tally['review']} review, {tally['likely-live']} likely-live")
+    print("CONSERVATIVE — verify before deleting. Notes:")
+    for n in heuristic_notes:
+        print(f"  • {n}")
+
+
+# ---------------------------------------------------------------------------
 # Solution discovery
 # ---------------------------------------------------------------------------
 
@@ -1183,6 +1820,27 @@ def main():
     dead_parser.add_argument("--verbose", action="store_true",
                              help="Show low-confidence results")
 
+    # confirm
+    confirm_parser = subparsers.add_parser(
+        "confirm",
+        help="Enrich dead candidates with batched deterministic judgment signals",
+    )
+    confirm_parser.add_argument("-s", "--solution", help="Solution name")
+    confirm_parser.add_argument(
+        "-t", "--type", required=True,
+        choices=["fields", "scripts", "custom_functions", "layouts", "value_lists"],
+        help="Object type to confirm",
+    )
+    confirm_parser.add_argument("--json", action="store_true",
+                                help="Emit JSON instead of the text table")
+    confirm_parser.add_argument("--verbose", action="store_true",
+                                help="Also show low-confidence (heuristic-excluded) candidates")
+    confirm_parser.add_argument(
+        "--canvas-strict", action="store_true",
+        help="Let off-canvas placement demote a medium field to likely-dead "
+             "(default: off-canvas is informational only)",
+    )
+
     args = parser.parse_args()
     solution = resolve_solution(args.solution)
 
@@ -1192,6 +1850,8 @@ def main():
         cmd_query(solution, args.type, args.name, args.direction)
     elif args.command == "dead":
         cmd_dead(solution, args.type, args.verbose)
+    elif args.command == "confirm":
+        cmd_confirm(solution, args.type, args.json, args.verbose, args.canvas_strict)
 
 
 if __name__ == "__main__":

--- a/agent/scripts/trace.py
+++ b/agent/scripts/trace.py
@@ -498,6 +498,21 @@ def parse_layouts(solution_dir, solution_name, to_map):
     return refs
 
 
+# Layout-object properties whose value is a calculation (or list of calcs).
+# Field references inside these are LIVE reads — a portal filter, hide condition,
+# conditional-format rule, tooltip, or button parameter all read the fields they
+# name at runtime. Without mining them, a field used *only* in one of these is
+# false-flagged as dead (the dangerous direction — deleting live schema). Maps
+# the summary key to the xref source_location label.
+LAYOUT_CALC_KEYS = {
+    "filter": "portal filter",
+    "hideWhen": "hide calc",
+    "tooltip": "tooltip calc",
+    "param": "button param calc",
+    "conditionalFormatCalcs": "conditional format calc",
+}
+
+
 def _walk_layout_json(obj, source_name, to_map, refs):
     """Recursively walk layout JSON for field/script references."""
     if isinstance(obj, dict):
@@ -523,6 +538,26 @@ def _walk_layout_json(obj, source_name, to_map, refs):
                 "layout", source_name, location,
                 "script", obj["script"], "",
             ))
+
+        # Calc-valued properties (portal filter, hide condition, conditional
+        # formatting, tooltip, button param). Tokenise each for TO::Field reads
+        # and resolve to the canonical base field — the same resolution the
+        # script-step and auto-enter parsers use.
+        for key, location in LAYOUT_CALC_KEYS.items():
+            val = obj.get(key)
+            if val is None:
+                continue
+            calc_strings = val if isinstance(val, list) else [val]
+            for calc in calc_strings:
+                if not isinstance(calc, str):
+                    continue
+                for m in RE_TO_FIELD.finditer(calc):
+                    to_name, field_name = m.group(1).strip(), m.group(2).strip()
+                    canonical, context = resolve_to_field(to_name, field_name, to_map)
+                    refs.append(XRef(
+                        "layout", source_name, location,
+                        "field", canonical, context,
+                    ))
 
         # Recurse into all values
         for v in obj.values():


### PR DESCRIPTION
Follow-on to #57. #57 made the engine *see* everything; this makes the agent able to *afford to analyse* it. Addresses #58.

`dead` emits candidates but does none of the judgment, so it's hand-cranked per candidate. `confirm` computes the deterministic half in one pass and suggests a conservative disposition that never auto-deletes.

**Per candidate:**
- **name-string hits** (SELF vs EXTERNAL), labelled by **HIT-KIND**: `benign` (placeholder/label — cannot invoke) < `calc` (hideWhen/merge/calc — a live reference) < `caller` (Perform-by-name / Go-to-Layout-`$var`). Merge fields `<<Table::Field>>` are classified `calc`.
- **table-qualified field probes** — the bare field name is matched only when unique across tables, so a same-named field on another table can't cross-rescue.
- **referrer-liveness (fields)** — a `calc`/`caller` hit from a referrer that is itself *live* promotes the field to `likely-live` (keep at a glance); `review` is reserved for held/dead-referrer, entry-point, or dynamic cases.
- **dynamic-reachable** flag, an **on/off-canvas** verdict from existing layout-summary bounds (informational by default; `--canvas-strict` to act on it), and an **external-entry-point** hint.

**Compatibility:** `cmd_dead` is refactored to share `compute_dead_candidates()`; `dead` output is **byte-for-byte unchanged**. New subparser flags: `--json`, `--verbose`, `--canvas-strict`.

**Validation:** measured on a real production audit — judgment-layer tool calls ~4.6x fewer, wall-clock ~6x faster, confirmed-dead set verified correct.

**Stacked on #57** (reuses its module/trigger functions) — please merge after #57.

**Deferred follow-ups (not this PR):** capture merge-field refs in the xref *build*; reference-type-aware referrer-liveness for layouts/VLs/scripts; a focused `confirm -n <name>` for single-object queries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
