### PR TITLE
fmcontext: build fields.index in one pass (fix CR corruption + per-field xmllint perf)

### DIFF
--- a/fmcontext.sh
+++ b/fmcontext.sh
@@ -182,58 +182,74 @@ for SOLUTION in "${SOLUTIONS[@]}"; do
         echo "# TableName|TableID|FieldName|FieldID|DataType|FieldType|AutoEnter|Flags"
 
         if [[ -d "$XML_PARSED_DIR/tables/$SOLUTION" ]]; then
-        find "$XML_PARSED_DIR/tables/$SOLUTION" -name '*.xml' -type f 2>/dev/null | sort | while IFS= read -r file; do
-            table_name=$(xval 'string(/FieldCatalog/BaseTableReference/@name)' "$file")
-            table_id=$(xval 'string(/FieldCatalog/BaseTableReference/@id)' "$file")
+        # Single Python pass per table (xml.etree) instead of one xmllint call
+        # per field/attribute. Orders of magnitude faster on large tables, and it
+        # flattens carriage returns (FileMaker calcs separate lines with Char 13,
+        # not \n) so a multi-line calc cannot spill a field across several index
+        # lines. Output format is identical to the previous xmllint-based loop.
+        python3 - "$XML_PARSED_DIR/tables/$SOLUTION" <<'PYFIELDS'
+import sys, os, glob
+import xml.etree.ElementTree as ET
 
-            field_count=$(xval 'count(//Field)' "$file")
-            field_count=${field_count:-0}
+tables_dir = sys.argv[1]
 
-            for ((i=1; i<=field_count; i++)); do
-                fname=$(xval "string(//Field[$i]/@name)" "$file")
-                fid=$(xval "string(//Field[$i]/@id)" "$file")
-                dtype=$(xval "string(//Field[$i]/@datatype)" "$file")
-                ftype=$(xval "string(//Field[$i]/@fieldtype)" "$file")
 
-                # Auto-enter: prefer the calculation text, fall back to the type attribute
-                auto_enter=""
-                auto_type=$(xval "string(//Field[$i]/AutoEnter/@type)" "$file")
-                if [[ "$auto_type" == "Calculated" ]]; then
-                    auto_calc=$(xval "string(//Field[$i]/AutoEnter/Calculated/Calculation/Text)" "$file")
-                    # Collapse multi-line calcs to single line (preserve readability)
-                    auto_calc=$(echo "$auto_calc" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ //;s/ $//')
-                    auto_enter="auto:${auto_calc}"
-                elif [[ -n "$auto_type" ]]; then
-                    auto_enter="auto:${auto_type}"
-                fi
+def flatten(node):
+    # Concatenate all text (matches xmllint string()), then collapse every
+    # whitespace run - including \r and \n - to a single space and trim.
+    if node is None:
+        return ""
+    text = "".join(node.itertext())
+    return " ".join(text.replace("\r", " ").replace("\n", " ").split())
 
-                # For calculated fields, extract the calculation formula
-                if [[ "$ftype" == "Calculated" && -z "$auto_enter" ]]; then
-                    calc_text=$(xval "string(//Field[$i]/Calculation/Text)" "$file")
-                    if [[ -n "$calc_text" ]]; then
-                        calc_text=$(echo "$calc_text" | tr '\n' ' ' | sed 's/  */ /g' | sed 's/^ //;s/ $//')
-                        auto_enter="calc:${calc_text}"
-                    fi
-                fi
 
-                # Flags: collect validation and storage flags
-                flags=""
-                not_empty=$(xval "string(//Field[$i]/Validation/@notEmpty)" "$file")
-                unique=$(xval "string(//Field[$i]/Validation/@unique)" "$file")
-                global=$(xval "string(//Field[$i]/Storage/@global)" "$file")
-                stored=$(xval "string(//Field[$i]/Storage/@storeCalculationResults)" "$file")
+for file in sorted(glob.glob(os.path.join(tables_dir, "*.xml"))):
+    try:
+        root = ET.parse(file).getroot()
+    except ET.ParseError:
+        continue
+    btr = root.find("BaseTableReference")
+    table_name = btr.get("name", "") if btr is not None else ""
+    table_id = btr.get("id", "") if btr is not None else ""
+    for field in root.iter("Field"):
+        fname = field.get("name", "")
+        fid = field.get("id", "")
+        dtype = field.get("datatype", "")
+        ftype = field.get("fieldtype", "")
 
-                [[ "$not_empty" == "True" ]] && flags="${flags}notEmpty,"
-                [[ "$unique" == "True" ]] && flags="${flags}unique,"
-                [[ "$global" == "True" ]] && flags="${flags}global,"
-                [[ "$stored" == "False" ]] && flags="${flags}unstored,"
+        # Auto-enter: prefer the calculation text, fall back to the type attribute
+        auto_enter = ""
+        ae = field.find("AutoEnter")
+        auto_type = ae.get("type", "") if ae is not None else ""
+        if auto_type == "Calculated":
+            auto_enter = "auto:" + flatten(ae.find("Calculated/Calculation/Text"))
+        elif auto_type:
+            auto_enter = "auto:" + auto_type
 
-                # Trim trailing comma
-                flags="${flags%,}"
+        # For calculated fields, extract the calculation formula
+        if ftype == "Calculated" and not auto_enter:
+            calc_text = flatten(field.find("Calculation/Text"))
+            if calc_text:
+                auto_enter = "calc:" + calc_text
 
-                echo "${table_name}|${table_id}|${fname}|${fid}|${dtype}|${ftype}|${auto_enter}|${flags}"
-            done
-        done
+        # Flags: collect validation and storage flags
+        flags = []
+        val = field.find("Validation")
+        if val is not None:
+            if val.get("notEmpty") == "True":
+                flags.append("notEmpty")
+            if val.get("unique") == "True":
+                flags.append("unique")
+        sto = field.find("Storage")
+        if sto is not None:
+            if sto.get("global") == "True":
+                flags.append("global")
+            if sto.get("storeCalculationResults") == "False":
+                flags.append("unstored")
+
+        print("|".join([table_name, table_id, fname, fid, dtype, ftype,
+                        auto_enter, ",".join(flags)]))
+PYFIELDS
         fi
     } > "$SOLUTION_CONTEXT_DIR/fields.index"
 


### PR DESCRIPTION
## Problem

`fmcontext.sh` builds `fields.index` for the agent's grep-based lookups. The field section has two issues that compound on real solutions.

### 1. Correctness: carriage returns corrupt the index

The flattening only handles `\n`:

```sh
auto_calc=$(echo "$auto_calc" | tr '\n' ' ' | ...)
```

FileMaker calculations separate lines with **CR (Char 13 / `\r`)**, not `\n`. Multi-line auto-enter and calculated-field formulas therefore keep their `\r`, which lands verbatim in the pipe-delimited `fields.index`.

`grep` doesn't notice (it splits on `\n`), but Python opens files in universal-newline mode and splits on `\r` too. A single field with a multi-line `Let([ ... ])` / `Case( ... )` value becomes several physical lines, most with an empty field-name column.

This crashes `analyze.py`:

```
File ".../analyze.py", line 1071, in detect_naming_conventions
    elif fname[0].isupper() and "_" not in fname:
IndexError: string index out of range
```

(`fname` is `""` for the spilled continuation lines.) The same broken rows make the documented `grep "FieldName" fields.index` lookups return garbage for those fields.

### 2. Performance: one `xmllint` per field

The field loop spawns `xmllint --xpath` once per field and once per attribute. On a large table that is thousands of sequential process starts. On our solution a translation table with 2000+ fields made the whole `fmcontext.sh` run take hours.

## Fix

Replace the per-field `xmllint` loop with a single `xml.etree` pass per table file. It emits every field row at once and flattens `\r`/`\n`/whitespace, so a field is always exactly one index line.

- **Output format unchanged** - verified row-for-row against the previous `xmllint` extraction (same columns, same `auto:`/`calc:` prefixes, same flags).
- Standard library only (matches the project's no-dependency stance).

## Verification (40-file solution, ~24.8k fields)

| metric | before | after |
|---|---|---|
| full `fmcontext.sh` run | hours | ~45 s |
| fields section | (stuck) | 0.4 s for 24,842 fields |
| `\r` in `fields.index` | 19 | 0 |
| `analyze.py` | `IndexError` | runs clean (~2 s) |

Scope is limited to the `fields.index` block. The same `tr '\n'` gap likely affects `relationships.index` / `value_lists.index`, but that is left for a follow-up.
