### PR TITLE
fix(fmlint): treat AGFMEvaluation "?" result as a failure

### DIFF
--- a/agent/fmlint/rules/live_eval.py
+++ b/agent/fmlint/rules/live_eval.py
@@ -181,6 +181,21 @@ class LiveEvalError(LintRule):
                     ),
                     line=line,
                 ))
+            elif str(result.get("result", "")).strip() == "?":
+                # AGFMEvaluation reports success even when the engine returns "?"
+                # (unknown custom function, missing reference, or a feature the
+                # host server does not support). EvaluationError only catches
+                # syntax errors, so guard the "?" sentinel here as a hard failure.
+                diags.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=self.default_severity,
+                    message=(
+                        f'Calculation evaluated to "?" in FileMaker engine — '
+                        f"likely an unknown custom function, missing reference, "
+                        f"or unsupported feature: {calc_text[:80]}"
+                    ),
+                    line=line,
+                ))
 
         return diags
 


### PR DESCRIPTION
Fixes the false-pass described in #65.

`AGFMEvaluation` reports `success: true` even when the live engine returns `"?"` — the sentinel for an unknown custom function, a missing reference, or a feature unsupported on the host server. Because tier-3 rule **C004** only flagged `success == false`, those calculations silently passed live validation.

This adds a guard in `live_eval.py`: when the engine returns `"?"`, C004 now emits an ERROR with a clear message ("likely an unknown custom function, missing reference, or unsupported feature"). No behavior change when the result is a real value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
