### PR TITLE
feat(fmlint): add param-fidelity rules to catch silent-discard params (X001-X003)

### DIFF
--- a/agent/catalogs/step-catalog-en.json
+++ b/agent/catalogs/step-catalog-en.json
@@ -2755,6 +2755,13 @@
         "required": false,
         "defaultValue": "False",
         "notes": "True when WebScript present. Not shown in HR."
+      },
+      {
+        "xmlElement": "UniversalPathList",
+        "type": "complex",
+        "hrLabel": null,
+        "required": false,
+        "notes": "Serialized among the leading boolean flags in the reference example (type='Reference'). Mirrors the Fine-Tune Model param; not shown in HR."
       }
     ],
     "hrSignature": "Generate Response from Model [ Account Name: {calc} ; Model: {calc} ; User Prompt: {calc} ; Agentic mode ; Response: {field|$variable} ; Tool Calls from Model: {$variable} ; Instructions: {calc} ; Messages: {$variable} ; Save Message History To: {$variable} ; Message History Count: {calc} ; Temperature: {calc} ; Tool Definitions: {calc} ; Stream ; Parameters: {calc} ; Web Viewer: {$object} ; Function Name: {calc} ]",
@@ -4470,6 +4477,14 @@
         "type": "text",
         "hrLabel": null,
         "required": false
+      },
+      {
+        "xmlElement": "Layout",
+        "type": "layout",
+        "hrLabel": null,
+        "required": false,
+        "discriminator": "LayoutDestination",
+        "notes": "Presence + shape governed by the sibling LayoutDestination (discriminator): none for Current/Original, <Layout id name/> for SelectedLayout, <Layout><Calculation/></Layout> for the by-calc forms. Without an explicit <LayoutDestination> FileMaker defaults to CurrentLayout and silently ignores this element."
       }
     ],
     "hrSignature": "[ Name: \"name\" ; Style: Document ]",

--- a/agent/fmlint/rules/__init__.py
+++ b/agent/fmlint/rules/__init__.py
@@ -7,3 +7,4 @@ from . import references  # noqa: F401
 from . import best_practices  # noqa: F401
 from . import calculations  # noqa: F401
 from . import live_eval  # noqa: F401
+from . import param_fidelity  # noqa: F401

--- a/agent/fmlint/rules/param_fidelity.py
+++ b/agent/fmlint/rules/param_fidelity.py
@@ -1,0 +1,291 @@
+"""Param-fidelity rules X001–X003 for FMLint.
+
+FileMaker's fmxmlsnippet parser **silently discards** child elements whose
+tag name does not match what the step expects: the step imports fine, but
+the parameter quietly falls back to its default value. These bugs are
+invisible at the XML-schema level and only manifest at runtime (e.g. a
+"Go to Record" that never advances, a Card window that opens as Document).
+
+These rules validate each <Step>'s child elements against the step catalog
+(`params[].xmlElement` et al. — see agent/catalogs/CATALOG_SCHEMA.md), so
+the silent-discard class of bugs is caught by the linter instead of being
+memorized as prose rules.
+
+Only catalog entries with status "complete" are enforced — per the schema
+contract, only those entries are fully reliable. Unknown catalog types are
+skipped rather than failed (forward-compatibility rule).
+"""
+
+import difflib
+
+from ..engine import rule, LintRule
+from ..types import Diagnostic, Severity
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _top_level_element(param: dict):
+    """Return the direct-child element name a param contributes to a Step.
+
+    Resolution order mirrors CATALOG_SCHEMA.md: a param nested under a
+    parentElement or wrapped by a wrapperElement surfaces as that container;
+    otherwise the base of xmlElement ("El" or "El/@attr" → "El").
+    """
+    parent = param.get("parentElement")
+    if isinstance(parent, str) and parent:
+        return parent
+    wrapper = param.get("wrapperElement")
+    if isinstance(wrapper, str) and wrapper:
+        return wrapper
+    xml_el = param.get("xmlElement")
+    if isinstance(xml_el, str) and xml_el:
+        return xml_el.split("/")[0]
+    return None
+
+
+def _allowed_children(entry: dict) -> set:
+    """Build the set of expected direct-child element names for a step."""
+    allowed = set()
+    for param in entry.get("params", []):
+        if not isinstance(param, dict):
+            continue
+        top = _top_level_element(param)
+        if top:
+            allowed.add(top)
+        ptype = param.get("type", "")
+        # Bare calculation params serialize as a <Calculation> child even
+        # when xmlElement carries a different logical name.
+        if ptype in ("calculation", "calc") :
+            allowed.add("Calculation")
+        # fieldOrVariable (and textMarker'd params) emit a leading <Text/>
+        # marker plus a <Field> element.
+        if ptype == "fieldOrVariable" or param.get("textMarker"):
+            allowed.add("Text")
+            allowed.add("Field")
+        # findRequests params serialize as the <Query> subtree.
+        if ptype == "findRequests":
+            allowed.add("Query")
+    return allowed
+
+
+def _entry_is_enforceable(entry) -> bool:
+    """Enforce only complete catalog entries (schema contract §status)."""
+    return bool(entry) and entry.get("status") == "complete"
+
+
+# Elements FileMaker emits/tolerates but the catalog deliberately does not
+# model as params. They are never a mistyped parameter name, so flagging
+# them would only produce noise:
+#   - Text: bare <Text/> markers appear next to field/variable targets in
+#     more step families than the catalog models with `textMarker`.
+#   - Animation: FileMaker Go-only; desktop FM drops it benignly on paste
+#     and at least one entry (Go to Related Record, `notesAnimation`)
+#     excludes it from params by design.
+GLOBAL_ALLOWED = {"Text", "Animation"}
+
+
+# ---------------------------------------------------------------------------
+# X001 — unknown-param-element
+# ---------------------------------------------------------------------------
+
+@rule
+class UnknownParamElement(LintRule):
+    """Child element not recognized by the step's catalog params.
+
+    FileMaker silently discards it and the parameter falls back to its
+    default (e.g. <State> instead of <Set> on Set Error Capture leaves
+    error capture OFF; <Option>/<ExitAfterLast> on Go to Record leave the
+    step with no parameters at all).
+    """
+
+    rule_id = "X001"
+    name = "unknown-param-element"
+    category = "param-fidelity"
+    default_severity = Severity.ERROR
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if parse_result.root is None:
+            return []
+        sev = self.severity(config)
+        diags = []
+        for idx, step in enumerate(parse_result.steps):
+            name = step.get("name", "")
+            entry = catalog.get(name)
+            if not _entry_is_enforceable(entry):
+                continue
+            allowed = _allowed_children(entry)
+            for child in list(step):
+                tag = child.tag
+                if tag in allowed or tag in GLOBAL_ALLOWED:
+                    continue
+                suggestion = difflib.get_close_matches(tag, sorted(allowed), n=1, cutoff=0.5)
+                hint = None
+                if suggestion:
+                    hint = f'Did you mean <{suggestion[0]}>? Check the catalog params for "{name}".'
+                elif allowed:
+                    hint = f'Expected elements for "{name}": {", ".join(sorted(allowed))}.'
+                else:
+                    hint = f'"{name}" takes no child elements.'
+                diags.append(Diagnostic(
+                    rule_id=self.rule_id,
+                    severity=sev,
+                    message=(
+                        f'Step {idx + 1} "{name}": <{tag}> is not a recognized '
+                        f"parameter element — FileMaker will silently discard it "
+                        f"and use the parameter's default value."
+                    ),
+                    line=0,
+                    fix_hint=hint,
+                ))
+        return diags
+
+
+# ---------------------------------------------------------------------------
+# X002 — missing-discriminator
+# ---------------------------------------------------------------------------
+
+@rule
+class MissingDiscriminator(LintRule):
+    """A param governed by a discriminator appears without it.
+
+    Catalog params may declare `discriminator`: a sibling param (typically
+    an enum) that governs their form/presence. Without the discriminator
+    element FileMaker falls back to its default and silently ignores the
+    governed param — e.g. <Layout> without <LayoutDestination> on
+    New Window / Go to Layout is ignored and the window opens on the
+    current layout.
+    """
+
+    rule_id = "X002"
+    name = "missing-discriminator"
+    category = "param-fidelity"
+    default_severity = Severity.ERROR
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if parse_result.root is None:
+            return []
+        sev = self.severity(config)
+        diags = []
+        for idx, step in enumerate(parse_result.steps):
+            name = step.get("name", "")
+            entry = catalog.get(name)
+            if not _entry_is_enforceable(entry):
+                continue
+            child_tags = {child.tag for child in list(step)}
+            for param in entry.get("params", []):
+                if not isinstance(param, dict):
+                    continue
+                disc = param.get("discriminator")
+                if not isinstance(disc, str) or not disc:
+                    continue
+                governed = _top_level_element(param)
+                disc_el = disc.split("/")[0]
+                if governed and governed in child_tags and disc_el not in child_tags:
+                    diags.append(Diagnostic(
+                        rule_id=self.rule_id,
+                        severity=sev,
+                        message=(
+                            f'Step {idx + 1} "{name}": <{governed}> is present but its '
+                            f"discriminator <{disc_el}> is missing — FileMaker will "
+                            f"silently ignore <{governed}> and use the default behavior."
+                        ),
+                        line=0,
+                        fix_hint=(
+                            f'Add <{disc_el} value="..."/> before <{governed}> '
+                            f"(e.g. <{disc_el} value=\"SelectedLayout\"/> for layout refs)."
+                        ),
+                    ))
+        return diags
+
+
+# ---------------------------------------------------------------------------
+# X003 — known-silent-discard-patterns
+# ---------------------------------------------------------------------------
+
+@rule
+class KnownSilentDiscardPatterns(LintRule):
+    """Hand-verified silent-discard combinations the generic rules can't see.
+
+    1. New Window with NewWndStyles Style="Card" but no Styles bitmask
+       attribute → FileMaker ignores Style and opens a Document window.
+    2. Perform Script with <FileReference> nested inside <Script> → the
+       cross-file script reference does not resolve ("unknown script").
+    3. Perform Script cross-file <FileReference> without a
+       <UniversalPathList> child → same unresolved-reference symptom.
+    """
+
+    rule_id = "X003"
+    name = "known-silent-discard-patterns"
+    category = "param-fidelity"
+    default_severity = Severity.ERROR
+    formats = {"xml"}
+    tier = 1
+
+    def check_xml(self, parse_result, catalog, context, config):
+        if parse_result.root is None:
+            return []
+        sev = self.severity(config)
+        diags = []
+        for idx, step in enumerate(parse_result.steps):
+            name = step.get("name", "")
+
+            # -- Pattern 1: Card window without the Styles bitmask ---------
+            if name == "New Window":
+                for styles_el in step.iter("NewWndStyles"):
+                    if styles_el.get("Style") == "Card" and not styles_el.get("Styles"):
+                        diags.append(Diagnostic(
+                            rule_id=self.rule_id,
+                            severity=sev,
+                            message=(
+                                f'Step {idx + 1} "New Window": Style="Card" without the '
+                                f'numeric Styles bitmask attribute — FileMaker ignores '
+                                f"Style and opens the window as Document."
+                            ),
+                            line=0,
+                            fix_hint=(
+                                'Add the Styles bitmask, e.g. Styles="3222339600" '
+                                "(Card, dim parent, no chrome except Close)."
+                            ),
+                        ))
+
+            # -- Patterns 2 & 3: Perform Script cross-file reference -------
+            if name in ("Perform Script", "Perform Script on Server"):
+                for script_el in step.findall("Script"):
+                    if script_el.find("FileReference") is not None:
+                        diags.append(Diagnostic(
+                            rule_id=self.rule_id,
+                            severity=sev,
+                            message=(
+                                f'Step {idx + 1} "{name}": <FileReference> is nested inside '
+                                f"<Script> — it must be a SIBLING of <Script>, or the "
+                                f"cross-file script reference will not resolve."
+                            ),
+                            line=0,
+                            fix_hint=(
+                                "Move <FileReference id name> up to be a direct child of "
+                                "the Step, before <Script>."
+                            ),
+                        ))
+                for fileref_el in step.findall("FileReference"):
+                    if fileref_el.find("UniversalPathList") is None:
+                        diags.append(Diagnostic(
+                            rule_id=self.rule_id,
+                            severity=sev,
+                            message=(
+                                f'Step {idx + 1} "{name}": <FileReference> without a '
+                                f"<UniversalPathList> child — the external file reference "
+                                f"will not resolve (script shows as unknown)."
+                            ),
+                            line=0,
+                            fix_hint=(
+                                "Add <UniversalPathList>file:FilenameWithoutExtension"
+                                "</UniversalPathList> inside <FileReference>."
+                            ),
+                        ))
+        return diags

--- a/agent/fmlint/tests/test_param_fidelity.py
+++ b/agent/fmlint/tests/test_param_fidelity.py
@@ -115,7 +115,7 @@ class ParamFidelityTestCase(unittest.TestCase):
             '<Step enable="True" id="1" name="Perform Script">'
             '<Calculation><![CDATA[$param]]></Calculation>'
             '<Script id="1363" name="Some Script">'
-            '<FileReference id="10" name="Controlador"/></Script></Step>'
+            '<FileReference id="10" name="OtherFile"/></Script></Step>'
         )
         msgs = [d.message for d in x_diags(result) if d.rule_id == "X003"]
         self.assertTrue(any("SIBLING" in m for m in msgs),
@@ -124,7 +124,7 @@ class ParamFidelityTestCase(unittest.TestCase):
     def test_x003_fileref_without_universal_path_list(self):
         result = self.lint(
             '<Step enable="True" id="1" name="Perform Script">'
-            '<FileReference id="10" name="Controlador"/>'
+            '<FileReference id="10" name="OtherFile"/>'
             '<Calculation><![CDATA[$param]]></Calculation>'
             '<Script id="1363" name="Some Script"/></Step>'
         )
@@ -135,8 +135,8 @@ class ParamFidelityTestCase(unittest.TestCase):
     def test_x003_crossfile_correct_form_passes(self):
         result = self.lint(
             '<Step enable="True" id="1" name="Perform Script">'
-            '<FileReference id="10" name="Controlador">'
-            '<UniversalPathList>file:Borneo-Controller</UniversalPathList>'
+            '<FileReference id="10" name="OtherFile">'
+            '<UniversalPathList>file:OtherFile</UniversalPathList>'
             '</FileReference>'
             '<Calculation><![CDATA[$param]]></Calculation>'
             '<Script id="1363" name="Some Script"/></Step>'

--- a/agent/fmlint/tests/test_param_fidelity.py
+++ b/agent/fmlint/tests/test_param_fidelity.py
@@ -1,0 +1,172 @@
+"""Tests for param-fidelity rules X001–X003.
+
+Two layers:
+1. Synthetic cases — one per known silent-discard bug (must fire) and the
+   corrected form of each (must be clean).
+2. Corpus smoke test — every reference example in agent/snippet_examples/
+   must produce zero X-family diagnostics (the corpus is ground truth; a
+   false positive there means the rule is miscalibrated).
+
+Run:  python3 -m unittest agent.fmlint.tests.test_param_fidelity
+"""
+
+import unittest
+from pathlib import Path
+
+from ..engine import LintRunner
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+WRAP = '<fmxmlsnippet type="FMObjectList">{}</fmxmlsnippet>'
+
+
+def x_diags(result):
+    """Only the param-fidelity family diagnostics."""
+    return [d for d in result.diagnostics if d.rule_id.startswith("X")]
+
+
+class ParamFidelityTestCase(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = LintRunner(project_root=REPO_ROOT)
+
+    def lint(self, inner_xml):
+        return self.runner.lint(WRAP.format(inner_xml), fmt="xml")
+
+    # -- X001: unknown param element ------------------------------------
+
+    def test_x001_set_error_capture_wrong_element(self):
+        # <State> instead of <Set> → error capture silently stays OFF
+        result = self.lint(
+            '<Step enable="True" id="86" name="Set Error Capture">'
+            '<State state="True"/></Step>'
+        )
+        diags = x_diags(result)
+        self.assertTrue(any(d.rule_id == "X001" and "<State>" in d.message.replace("&lt;", "<")
+                            or d.rule_id == "X001" and "State" in d.message
+                            for d in diags),
+                        f"expected X001 for <State>, got: {[d.message for d in diags]}")
+
+    def test_x001_go_to_record_wrong_elements(self):
+        # <Option>/<ExitAfterLast> instead of <RowPageLocation>/<Exit>
+        result = self.lint(
+            '<Step enable="True" id="16" name="Go to Record/Request/Page">'
+            '<Option value="First"/><ExitAfterLast state="True"/></Step>'
+        )
+        diags = [d for d in x_diags(result) if d.rule_id == "X001"]
+        self.assertEqual(len(diags), 2,
+                         f"expected 2 X001 diags, got: {[d.message for d in diags]}")
+
+    def test_x001_clean_forms_pass(self):
+        result = self.lint(
+            '<Step enable="True" id="86" name="Set Error Capture">'
+            '<Set state="True"/></Step>'
+            '<Step enable="True" id="16" name="Go to Record/Request/Page">'
+            '<NoInteract state="True"/><Exit state="True"/>'
+            '<RowPageLocation value="Next"/></Step>'
+        )
+        self.assertEqual(x_diags(result), [],
+                         f"clean steps flagged: {[d.message for d in x_diags(result)]}")
+
+    # -- X002: missing discriminator -------------------------------------
+
+    def test_x002_go_to_layout_without_destination(self):
+        result = self.lint(
+            '<Step enable="True" id="6" name="Go to Layout">'
+            '<Layout id="28" name="Clientes"></Layout></Step>'
+        )
+        diags = [d for d in x_diags(result) if d.rule_id == "X002"]
+        self.assertEqual(len(diags), 1,
+                         f"expected 1 X002 diag, got: {[d.message for d in x_diags(result)]}")
+
+    def test_x002_go_to_layout_with_destination_passes(self):
+        result = self.lint(
+            '<Step enable="True" id="6" name="Go to Layout">'
+            '<LayoutDestination value="SelectedLayout"/>'
+            '<Layout id="28" name="Clientes"></Layout></Step>'
+        )
+        self.assertEqual([d for d in x_diags(result) if d.rule_id == "X002"], [])
+
+    # -- X003: known silent-discard patterns ------------------------------
+
+    def test_x003_card_without_styles_bitmask(self):
+        result = self.lint(
+            '<Step enable="True" id="122" name="New Window">'
+            '<NewWndStyles DimParentWindow="Yes" Toolbars="No" MenuBar="No" '
+            'Style="Card" Close="Yes" Minimize="No" Maximize="No" Resize="No"/>'
+            '</Step>'
+        )
+        diags = [d for d in x_diags(result) if d.rule_id == "X003"]
+        self.assertEqual(len(diags), 1,
+                         f"expected 1 X003 diag, got: {[d.message for d in x_diags(result)]}")
+
+    def test_x003_card_with_styles_bitmask_passes(self):
+        result = self.lint(
+            '<Step enable="True" id="122" name="New Window">'
+            '<NewWndStyles DimParentWindow="Yes" Toolbars="No" MenuBar="No" '
+            'Style="Card" Close="Yes" Minimize="No" Maximize="No" Resize="No" '
+            'Styles="3222339600"/></Step>'
+        )
+        self.assertEqual([d for d in x_diags(result) if d.rule_id == "X003"], [])
+
+    def test_x003_fileref_nested_inside_script(self):
+        result = self.lint(
+            '<Step enable="True" id="1" name="Perform Script">'
+            '<Calculation><![CDATA[$param]]></Calculation>'
+            '<Script id="1363" name="Some Script">'
+            '<FileReference id="10" name="Controlador"/></Script></Step>'
+        )
+        msgs = [d.message for d in x_diags(result) if d.rule_id == "X003"]
+        self.assertTrue(any("SIBLING" in m for m in msgs),
+                        f"expected nested-FileReference diag, got: {msgs}")
+
+    def test_x003_fileref_without_universal_path_list(self):
+        result = self.lint(
+            '<Step enable="True" id="1" name="Perform Script">'
+            '<FileReference id="10" name="Controlador"/>'
+            '<Calculation><![CDATA[$param]]></Calculation>'
+            '<Script id="1363" name="Some Script"/></Step>'
+        )
+        msgs = [d.message for d in x_diags(result) if d.rule_id == "X003"]
+        self.assertTrue(any("UniversalPathList" in m for m in msgs),
+                        f"expected missing-UniversalPathList diag, got: {msgs}")
+
+    def test_x003_crossfile_correct_form_passes(self):
+        result = self.lint(
+            '<Step enable="True" id="1" name="Perform Script">'
+            '<FileReference id="10" name="Controlador">'
+            '<UniversalPathList>file:Borneo-Controller</UniversalPathList>'
+            '</FileReference>'
+            '<Calculation><![CDATA[$param]]></Calculation>'
+            '<Script id="1363" name="Some Script"/></Step>'
+        )
+        self.assertEqual([d for d in x_diags(result) if d.rule_id == "X003"], [])
+
+
+class CorpusSmokeTest(unittest.TestCase):
+    """Every reference example must be clean of X-family diagnostics."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.runner = LintRunner(project_root=REPO_ROOT)
+
+    def test_snippet_examples_corpus_is_clean(self):
+        corpus = REPO_ROOT / "agent" / "snippet_examples"
+        files = sorted(corpus.rglob("*.xml"))
+        self.assertGreater(len(files), 50, "corpus not found or too small")
+        failures = []
+        for path in files:
+            try:
+                result = self.runner.lint_file(str(path))
+            except Exception as exc:  # malformed reference file — not ours
+                failures.append(f"{path.relative_to(corpus)}: lint crashed: {exc}")
+                continue
+            for d in x_diags(result):
+                failures.append(f"{path.relative_to(corpus)}: {d.rule_id} {d.message}")
+        self.assertEqual(failures, [],
+                         "false positives in reference corpus:\n" + "\n".join(failures))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
FileMaker's fmxmlsnippet parser **silently discards** child elements whose tag doesn't match what a step expects — the step pastes fine, but the parameter quietly falls back to its default. These bugs are invisible at the XML-schema level and only manifest at runtime (a "Go to Record" that never advances, a Card window that opens as Document, an unresolved cross-file script reference).

## What this adds

Three catalog-driven fmlint rules:

- **X001 unknown-param-element** — flags a child element not recognized by the step's catalog `params[]`, with a difflib "did you mean" suggestion. Only enforced against catalog entries with `status: "complete"`; allowlists `{Text, Animation}` (elements FileMaker tolerates that the catalog deliberately doesn't model as params).
- **X002 missing-discriminator** — flags a param present without its required discriminator sibling (e.g. `<Layout>` without `<LayoutDestination>` on Go to Layout / New Window).
- **X003 known-silent-discard-patterns** — two hand-verified combinations: `Style="Card"` without the `Styles` bitmask (opens as Document instead); `<FileReference>` nested inside `<Script>` or missing `<UniversalPathList>` (cross-file script reference doesn't resolve).

Includes a synthetic test suite (11 cases) plus a mass smoke test against `snippet_examples/` (0 false positives). The smoke test surfaced two catalog gaps, fixed here: the `Layout` param was missing entirely from New Window, and `UniversalPathList` was missing from Generate Response from Model.

## Bonus fix

While porting this, found that the current `step-catalog-en.json` on `main` has **invalid JSON** — the `Layout` param entry under Go to Layout is missing a comma between `"notes"` and `"discriminator"`, so any strict JSON parser (including this catalog loader) fails to load the file at all. Fixed in the same commit since the new tests need a loadable catalog to run.

## Test plan

- [x] `python3 -m unittest agent.fmlint.tests.test_param_fidelity -v` — 11/11 pass
- [x] Smoke test against the full `snippet_examples/` corpus — 0 false positives