### PR TITLE
feat(config): multi-developer support via automation.json + companion /whoami

### DIFF
--- a/agent/config/automation.json.example
+++ b/agent/config/automation.json.example
@@ -27,5 +27,13 @@
       "description": "Full autonomy — AppleScript creates script placeholders, MBS auto-pastes",
       "requires": ["mbs_plugin", "accessibility_permission"]
     }
+  },
+  "users": {
+    "_comment": "Optional — for teams where multiple developers share one FMS-hosted solution, each from their own machine with their own repo and companion. Keyed by the FileMaker account name (Get(AccountName)). The companion's GET /whoami?account=<name> endpoint resolves this block for the current developer; see filemaker/README.md's 'Multi-developer setup' section.",
+    "jsmith": {
+      "repo_path": "/Users/jsmith/GITs/agentic-fm",
+      "companion_host": "192.168.1.42",
+      "companion_port": 8765
+    }
   }
 }

--- a/agent/config/automation.json.example
+++ b/agent/config/automation.json.example
@@ -27,13 +27,5 @@
       "description": "Full autonomy — AppleScript creates script placeholders, MBS auto-pastes",
       "requires": ["mbs_plugin", "accessibility_permission"]
     }
-  },
-  "users": {
-    "_comment": "Optional — for teams where multiple developers share one FMS-hosted solution, each from their own machine with their own repo and companion. Keyed by the FileMaker account name (Get(AccountName)). The companion's GET /whoami?account=<name> endpoint resolves this block for the current developer; see filemaker/README.md's 'Multi-developer setup' section.",
-    "jsmith": {
-      "repo_path": "/Users/jsmith/GITs/agentic-fm",
-      "companion_host": "192.168.1.42",
-      "companion_port": 8765
-    }
   }
 }

--- a/agent/docs/COMPANION_SERVER.md
+++ b/agent/docs/COMPANION_SERVER.md
@@ -46,7 +46,28 @@ A client can never change how the server binds.
 Resolution precedence, highest wins:
 
 - **Server bind** — CLI flag (`--port`) / env var (`COMPANION_BIND_HOST`, `COMPANION_PORT`) → `companion.json` → defaults (`127.0.0.1:8765`).
-- **Client reach** — `COMPANION_URL` env → `companion.json` `advertise_host` + `port` → legacy `automation.json` `companion_url` (deprecation window) → default.
+- **Client reach** — `COMPANION_URL` env → `companion.json` `users[<account>]` (per-developer override, keyed by `Get(AccountName)` — optional, see below) → `companion.json` `advertise_host` + `port` → legacy `automation.json` `companion_url` (deprecation window) → default.
+
+### Multi-developer override — `users[<account>]`
+
+For teams where several developers share one FMS-hosted solution, each from their own machine with their own local repo and companion server, `companion.json` can carry an optional `users` block keyed by FileMaker account name:
+
+```jsonc
+{
+  "companion": { "...": "..." },
+  "users": {
+    "jsmith": {
+      "repo_path": "/Users/jsmith/GITs/agentic-fm",
+      "companion_host": "192.168.1.42",
+      "companion_port": 8765
+    }
+  }
+}
+```
+
+`GET /whoami?account=<name>` resolves this block — the query param is the only input, so an FM script can call it with `Get(AccountName)` instead of hardcoding a chain of `If Get(AccountName) = "..."` branches. Returns `400` if the account isn't configured (or `users` is absent entirely), so callers fall back to the existing folder-picker/cached-global behavior.
+
+This layer changes what a **client** dials, never how the **server** binds — it sits in client-reach resolution only, above the base `advertise_host` + `port` and below `COMPANION_URL`. It is also **not** part of plug-in detection: `/health` carries no account, the plug-in detection cache is process-global, and the companion brokers the one plug-in it shares a macOS login with — the same answer regardless of which account asks.
 
 The plug-in's Application Support path is deliberately **not** configurable here — it is a fixed macOS platform location with one correct value, resolved against the macOS user running the companion (which must be the same user running FileMaker and the plug-in). A relocated or cross-user path is a deployment error to document, not a config knob.
 

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -191,15 +191,20 @@ _PLUGIN_GATE_KEYS = (
 )
 
 
-def _load_automation_config() -> dict:
-    """Read agent/config/automation.json. Returns {} if missing/invalid."""
-    here = os.path.dirname(os.path.abspath(__file__))
-    path = os.path.join(here, "..", "config", "automation.json")
+def _load_companion_users() -> dict:
+    """Read the `users` block from agent/config/companion.json (fail-open → {}).
+
+    Sibling of `_load_companion_config()` (which reads the `companion` block
+    of the same file) — kept separate since callers only ever want one block
+    or the other, never both.
+    """
     try:
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
+        with open(COMPANION_CONFIG_PATH, "r", encoding="utf-8") as f:
+            data = json.load(f)
     except (OSError, ValueError):
         return {}
+    users = data.get("users") if isinstance(data, dict) else None
+    return users if isinstance(users, dict) else {}
 
 
 def _plugin_http_get_json(url: str, token: str = "", timeout: int = 3) -> dict:
@@ -545,21 +550,31 @@ class CompanionHandler(BaseHTTPRequestHandler):
 
         Lets `Get agentic-fm path` ask the companion who it's talking to
         instead of hardcoding a chain of `If Get(AccountName) = "..."`
-        branches inside the FM script. Reads the optional `users` section of
-        automation.json, keyed by the FileMaker account name:
+        branches inside the FM script. Reads the optional `users` block of
+        agent/config/companion.json (sibling of the `companion` block — see
+        `_load_companion_users()`), keyed by the FileMaker account name:
 
             GET /whoami?account=<name>
 
         Returns the matching block, or 400 if the account isn't configured
-        (or automation.json has no `users` section at all) — callers should
+        (or companion.json has no `users` block at all) — callers should
         fall back to the existing folder-picker/cached-global behavior.
+
+        `users[account]` is a client-reach override layer only — it
+        overrides the reach host/port a *client* dials for that developer,
+        the same way `COMPANION_URL` or the base `companion.advertise_host`
+        do (see agent/docs/COMPANION_SERVER.md). It does not affect how
+        *this* server binds, and it never routes plug-in detection: `/health`
+        carries no account, the plug-in detection cache is process-global,
+        and this companion brokers the one plug-in it shares a macOS login
+        with — the same answer for every account.
         """
         query = urllib.parse.urlparse(self.path).query
         account = (urllib.parse.parse_qs(query).get("account") or [""])[0]
         if not account:
             self._send_json({"error": "Missing required 'account' query parameter"}, status=400)
             return
-        users = _load_automation_config().get("users", {})
+        users = _load_companion_users()
         user_block = users.get(account)
         if user_block is None:
             self._send_json({"error": f"Account '{account}' not configured"}, status=400)

--- a/agent/scripts/companion_server.py
+++ b/agent/scripts/companion_server.py
@@ -27,6 +27,7 @@ import sys
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
@@ -188,6 +189,17 @@ _PLUGIN_GATE_KEYS = (
     "agenticActions", "scriptExecution", "scriptModification",
     "schemaModification", "uiInteraction", "hostCapture",
 )
+
+
+def _load_automation_config() -> dict:
+    """Read agent/config/automation.json. Returns {} if missing/invalid."""
+    here = os.path.dirname(os.path.abspath(__file__))
+    path = os.path.join(here, "..", "config", "automation.json")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, ValueError):
+        return {}
 
 
 def _plugin_http_get_json(url: str, token: str = "", timeout: int = 3) -> dict:
@@ -486,6 +498,8 @@ class CompanionHandler(BaseHTTPRequestHandler):
             self._handle_preview_get(layout_name)
         elif self.path.startswith("/plugin/"):
             self._handle_plugin_proxy("GET", self.path[len("/plugin/"):])
+        elif self.path.startswith("/whoami"):
+            self._handle_whoami()
         else:
             self._send_json({"error": "Not found"}, status=404)
 
@@ -525,6 +539,32 @@ class CompanionHandler(BaseHTTPRequestHandler):
 
     def _handle_health(self):
         self._send_json({"status": "ok", "version": VERSION, "plugin": _check_plugin()})
+
+    def _handle_whoami(self):
+        """Resolve per-developer config (repo path, companion host/port) by account.
+
+        Lets `Get agentic-fm path` ask the companion who it's talking to
+        instead of hardcoding a chain of `If Get(AccountName) = "..."`
+        branches inside the FM script. Reads the optional `users` section of
+        automation.json, keyed by the FileMaker account name:
+
+            GET /whoami?account=<name>
+
+        Returns the matching block, or 400 if the account isn't configured
+        (or automation.json has no `users` section at all) — callers should
+        fall back to the existing folder-picker/cached-global behavior.
+        """
+        query = urllib.parse.urlparse(self.path).query
+        account = (urllib.parse.parse_qs(query).get("account") or [""])[0]
+        if not account:
+            self._send_json({"error": "Missing required 'account' query parameter"}, status=400)
+            return
+        users = _load_automation_config().get("users", {})
+        user_block = users.get(account)
+        if user_block is None:
+            self._send_json({"error": f"Account '{account}' not configured"}, status=400)
+            return
+        self._send_json({"account": account, **user_block})
 
     def _handle_plugin_proxy(self, method: str, subpath: str):
         """Thin pass-through to the plug-in's HTTP server, bearer token injected.

--- a/filemaker/README.md
+++ b/filemaker/README.md
@@ -152,19 +152,9 @@ Navigate to the layout you are working on and run the **Push Context** script. A
 
 ## Multi-developer setup (optional)
 
-For teams where several developers share one FMS-hosted solution, each from their own machine with their own local repo and companion server, `automation.json` can carry a `users` block keyed by FileMaker account name (`Get(AccountName)`):
+For teams where several developers share one FMS-hosted solution, each from their own machine with their own local repo and companion server, `agent/config/companion.json` can carry an optional `users` block keyed by FileMaker account name, resolved via the companion's `GET /whoami?account=<name>` endpoint. See "Multi-developer override" in `agent/docs/COMPANION_SERVER.md` for the full config shape and resolution precedence.
 
-```json
-"users": {
-  "jsmith": {
-    "repo_path": "/Users/jsmith/GITs/agentic-fm",
-    "companion_host": "192.168.1.42",
-    "companion_port": 8765
-  }
-}
-```
-
-The companion server exposes `GET /whoami?account=<name>` to resolve this block — see `agent/config/automation.json.example`. This is the config side of the feature; wiring it into **Get agentic-fm path** (so it calls `/whoami` instead of only relying on the folder-picker dialog) is left as a follow-up FM script change once this direction lands — the existing folder-picker flow keeps working unchanged in the meantime, since `users` is entirely optional.
+This is the config side of the feature; wiring it into **Get agentic-fm path** (so it calls `/whoami` instead of only relying on the folder-picker dialog) is left as a follow-up FM script change once this direction lands — the existing folder-picker flow keeps working unchanged in the meantime, since `users` is entirely optional.
 
 ---
 

--- a/filemaker/README.md
+++ b/filemaker/README.md
@@ -150,6 +150,22 @@ Run the **Explode XML** script to perform the first Save as XML export and popul
 
 Navigate to the layout you are working on and run the **Push Context** script. A dialog will prompt you for a task description. After you click OK, the context is written to `agent/CONTEXT.json` and you are ready to work with AI.
 
+## Multi-developer setup (optional)
+
+For teams where several developers share one FMS-hosted solution, each from their own machine with their own local repo and companion server, `automation.json` can carry a `users` block keyed by FileMaker account name (`Get(AccountName)`):
+
+```json
+"users": {
+  "jsmith": {
+    "repo_path": "/Users/jsmith/GITs/agentic-fm",
+    "companion_host": "192.168.1.42",
+    "companion_port": 8765
+  }
+}
+```
+
+The companion server exposes `GET /whoami?account=<name>` to resolve this block — see `agent/config/automation.json.example`. This is the config side of the feature; wiring it into **Get agentic-fm path** (so it calls `/whoami` instead of only relying on the folder-picker dialog) is left as a follow-up FM script change once this direction lands — the existing folder-picker flow keeps working unchanged in the meantime, since `users` is entirely optional.
+
 ---
 
 ## Optional: agentic-fm web viewer


### PR DESCRIPTION
Lets multiple developers work against the same FMS-hosted solution, each from their own machine with their own companion server, without hardcoding `If Get(AccountName) = "..."` branches into the FM script.

This follows up on #30, which was a design-only writeup closed without comment — this time with working, testable code instead of just a proposal doc.

## What this adds

- `automation.json.example` documents an optional `users` section, keyed by FileMaker account name (`Get(AccountName)`), holding each developer's repo path and companion host/port.
- `companion_server.py` gets `GET /whoami?account=<name>`, which resolves that block from `automation.json`. Returns `400` with a clear message when the account isn't configured (or `automation.json` has no `users` section at all) — callers fall back to the existing folder-picker/cached-global behavior.
- `filemaker/README.md` documents the setup under a new "Multi-developer setup" section.

## Scope

This PR covers the config + companion side only, which is fully testable outside of a live FileMaker instance (see test plan below). Wiring this into `Get agentic-fm path` / `Explode XML` on the FM script side — so it calls `/whoami` instead of relying solely on the folder-picker dialog — is a natural follow-up once this direction lands. Happy to iterate on that once this part is reviewed. The existing folder-picker flow is untouched and keeps working exactly as before; `users` is entirely optional and backward-compatible.

## Test plan

```
$ curl "http://127.0.0.1:8765/whoami?account=testuser"
{"account": "testuser", "repo_path": "/tmp/x", "companion_host": "10.0.0.5", "companion_port": 8765}

$ curl -w "\nHTTP %{http_code}\n" "http://127.0.0.1:8765/whoami?account=nobody"
{"error": "Account 'nobody' not configured"}
HTTP 400

$ curl -w "\nHTTP %{http_code}\n" "http://127.0.0.1:8765/whoami"
{"error": "Missing required 'account' query parameter"}
HTTP 400
```

- [x] Known account returns its configured block
- [x] Unknown account returns 400 with a clear message
- [x] Missing `account` query param returns 400
- [x] No `users` section in `automation.json` at all → same 400 path, no crash