### PR TITLE
Fix invalid JSON in step-catalog-en.json (missing comma breaks fmlint)

### DIFF
--- a/agent/catalogs/step-catalog-en.json
+++ b/agent/catalogs/step-catalog-en.json
@@ -2954,7 +2954,7 @@
         "type": "layout",
         "hrLabel": null,
         "required": false,
-        "notes": "Sibling of LayoutDestination — NOT nested inside it. Must use explicit open/close tags: <Layout id=\"N\" name=\"Name\"></Layout>. Self-closing form is silently dropped by FileMaker on paste."
+        "notes": "Sibling of LayoutDestination — NOT nested inside it. Must use explicit open/close tags: <Layout id=\"N\" name=\"Name\"></Layout>. Self-closing form is silently dropped by FileMaker on paste.",
         "discriminator": "LayoutDestination"
       },
       {


### PR DESCRIPTION
The `Go to Layout` step's `Layout` param (added in the GoToLayoutFix change)
is missing a comma after its "notes" value, so step-catalog-en.json is not
valid JSON.

Because fmlint loads this catalog on every XML lint (catalog.has_step ->
json.load), the whole linter fails with:

    json.decoder.JSONDecodeError: Expecting ',' delimiter (line ~2958)

Fix: add the missing comma after the "notes" line. Verified the file parses
and `python3 -m agent.fmlint` runs again afterward.