### PR TITLE
Fix C004 live-eval parsing of nested AGFMScriptBridge envelope

### DIFF
--- a/agent/fmlint/rules/live_eval.py
+++ b/agent/fmlint/rules/live_eval.py
@@ -74,11 +74,30 @@ def _evaluate_expression(odata_config, expression, layout=None):
     rp = result.get("resultParameter", "")
     if isinstance(rp, str) and rp:
         try:
-            return json.loads(rp)
+            result = json.loads(rp)
         except json.JSONDecodeError:
             pass
 
-    return result
+    # Some AGFMScriptBridge builds wrap the evaluation verdict one layer
+    # deeper: the outer envelope's `result` is itself a JSON string holding the
+    # real {error_code, result, success}. Peel nested JSON-object string layers
+    # so the caller sees the actual verdict — otherwise a genuine "?" result
+    # hides behind the outer envelope's success:true and is never flagged.
+    for _ in range(3):
+        if not isinstance(result, dict):
+            break
+        inner = result.get("result")
+        if isinstance(inner, str):
+            stripped = inner.strip()
+            if stripped.startswith("{") and stripped.endswith("}"):
+                try:
+                    result = json.loads(stripped)
+                    continue
+                except json.JSONDecodeError:
+                    pass
+        break
+        
+return result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
C004 (live-eval-error) validates calculations against the live FileMaker
engine via AGFMEvaluation over OData. On my server, AGFMScriptBridge returns
a double-nested envelope:

    outer:  { "success": true, "result": "<json string>" }
    inner:  { "error_code": 0, "result": "?", "success": true }

_evaluate_expression only peeled the outer layer, so a genuine "?" verdict
(unknown custom function / missing reference / unsupported feature) stayed
hidden behind the outer "success": true — C004 reported no diagnostics for
calcs that are actually broken (a false all-clear).

This peels nested JSON-object `result` string layers (bounded to 3) before
returning, so the caller sees the real verdict. Verified against a live
solution: C004 now correctly flags Middle("hello";2) and unknown-function
calcs, while valid calcs still pass. Single-layer responses are unaffected
(the loop stops as soon as `result` isn't a JSON-object string).