### PR TITLE
Support a local, gitignored coding-conventions override

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -191,7 +191,7 @@ The developer always works in **human-readable (HR) script format**. The agent's
 **MANDATORY: Before writing ANY script or function:**
 
 1. Read `agent/CONTEXT.json` for the task description and all reference IDs (when present)
-2. Read `agent/docs/CODING_CONVENTIONS.md` — all generated FileMaker code must follow these conventions
+2. Read coding conventions — check for `agent/docs/CODING_CONVENTIONS.local.md` first (gitignored, developer's personal/local override); if it exists, read it **instead of** `agent/docs/CODING_CONVENTIONS.md` and follow it exclusively. Otherwise read `agent/docs/CODING_CONVENTIONS.md`. All generated FileMaker code must follow whichever file applies.
 3. Scan `agent/docs/knowledge/MANIFEST.md` for keyword matches against the current task — read and apply matching documents
 4. For scripts: grep the step catalog for each step type used (see **Step catalog** below)
 5. Substitute the specific IDs/names/values from CONTEXT.json

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ agent/docs/filemaker/error-codes.md
 
 # Specific files
 PROJECT.md
+agent/docs/CODING_CONVENTIONS.local.md
 *_PRIVATE.md
 Prompt.md
 .cursorignore

--- a/README.md
+++ b/README.md
@@ -193,7 +193,12 @@ agentic-fm/
 
 All AI-generated FileMaker code (scripts and calculations) follows the conventions defined in `agent/docs/CODING_CONVENTIONS.md`. These are "initially set" based on the community standard at [filemakerstandards.org](https://filemakerstandards.org/code) and cover variable naming prefixes (`$`, `$$`, `~`, `$$~`), `Let()` formatting, operator spacing, boolean values, and control structure style.
 
-**You can, and probably should, customize these conventions to your preferred style.** Edit `agent/docs/CODING_CONVENTIONS.md` to match your team's standards. AI reads this file before writing any calculation or script logic and will follow whatever rules you define there. Common customizations include:
+**You can, and probably should, customize these conventions to your preferred style.** There are two ways to do this:
+
+- **Team-wide, checked in:** Edit `agent/docs/CODING_CONVENTIONS.md` directly. Changes are committed and shared with everyone who clones the repo.
+- **Personal, local-only:** Create `agent/docs/CODING_CONVENTIONS.local.md` (gitignored — never committed). When this file exists, AI reads it *instead of* the checked-in version, so you can keep your own preferences without affecting collaborators or the repo.
+
+AI reads whichever file applies before writing any calculation or script logic and follows whatever rules are defined there. Common customizations include:
 
 - Changing variable naming conventions or casing style
 - Adding project-specific prefixes or naming patterns

--- a/agent/docs/CODING_CONVENTIONS.md
+++ b/agent/docs/CODING_CONVENTIONS.md
@@ -2,6 +2,8 @@
 
 Source: [filemakerstandards.org/code](https://filemakerstandards.org/code)
 
+> **Want your own conventions without editing this checked-in file?** Create `agent/docs/CODING_CONVENTIONS.local.md` (gitignored). When present, the agent reads that file instead of this one — see `.claude/CLAUDE.md`.
+
 > **CRITICAL — Hard Tabs for Indentation**
 >
 > All indentation inside calculations and expressions MUST use hard tab characters (ASCII 0x09), never spaces. This applies to `Let()` variables, `Case()` branches, `List()` arguments, and any nested function content that appears inside CDATA blocks in fmxmlsnippet output. AI-generated code must use literal `\t` tab characters for calculation indentation. In the FileMaker calculation dialog, use Option-Tab (Mac) or Ctrl-Tab (Win) to insert a tab.


### PR DESCRIPTION
## Summary
- Add `agent/docs/CODING_CONVENTIONS.local.md` as a gitignored override path so developers can maintain personal coding conventions without editing the checked-in team file.
- The agent's mandatory pre-write step (`.claude/CLAUDE.md`, symlinked as `AGENTS.md`) now checks for the local file first and follows it exclusively when present, falling back to the checked-in `CODING_CONVENTIONS.md` otherwise.
- Documented both customization paths (team-wide checked-in vs. personal local-only) in README.md and at the top of `CODING_CONVENTIONS.md`.

## Test plan
- [ ] Confirm `agent/docs/CODING_CONVENTIONS.local.md` is correctly ignored by git (`git status` shows it untracked/ignored)
- [ ] Start a new agent session, create a local override with a distinct rule, and confirm generated FileMaker code follows the local file instead of the checked-in one

🤖 Generated with [Claude Code](https://claude.com/claude-code)